### PR TITLE
feat: tt cutoff in qsearch

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -542,8 +542,6 @@ i32 Raphael::quiescence(
         const i32 score = -quiescence<is_PV>(board, ply + 1, -beta, -alpha, halt);
         board.unmake_move(move);
 
-        if (halt) return 0;
-
         if (score > bestscore) {
             bestscore = score;
 
@@ -561,7 +559,7 @@ i32 Raphael::quiescence(
     }
 
     // update transposition table
-    tt.set({ttkey, 0, ttflag, bestmove, bestscore}, ply);
+    if (!halt) tt.set(ttkey, bestscore, bestmove, 0, ttflag, ply);
 
     return bestscore;
 }

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -520,8 +520,6 @@ i32 Raphael::quiescence(
 
     // search
     i32 bestscore = static_eval;
-    chess::Move bestmove = chess::Move::NO_MOVE;
-    auto ttflag = tt.UPPER;
 
     const i32 futility = bestscore + QS_FUTILITY_MARGIN;
 
@@ -547,19 +545,10 @@ i32 Raphael::quiescence(
 
             if (score > alpha) {
                 alpha = score;
-                bestmove = move;
-                ttflag = tt.EXACT;
-
-                if (score >= beta) {
-                    ttflag = tt.LOWER;
-                    break;  // prune
-                }
+                if (score >= beta) break;  // prune
             }
         }
     }
-
-    // update transposition table
-    if (!halt) tt.set(ttkey, bestscore, bestmove, 0, ttflag, ply);
 
     return bestscore;
 }

--- a/src/Raphael/Transposition.cpp
+++ b/src/Raphael/Transposition.cpp
@@ -55,6 +55,10 @@ void TranspositionTable::set(u64 key, i32 score, chess::Move move, i32 depth, Fl
     assert(depth >= 0);
     assert(depth < 256);
 
+    Entry entry = table_[index(key)];
+
+    if (move != chess::Move::NO_MOVE || entry.key != key) entry.move = move;
+
     // correct mate score when storing (https://youtu.be/XfeuxubYlT0)
     if (utils::is_loss(score))
         score -= ply;
@@ -62,8 +66,12 @@ void TranspositionTable::set(u64 key, i32 score, chess::Move move, i32 depth, Fl
         score += ply;
 
     // set
-    table_[index(key)]
-        = {.key = key, .score = score, .move = move, .depth = static_cast<u8>(depth), .flag = flag};
+    entry.key = key;
+    entry.score = score;
+    entry.depth = static_cast<u8>(depth);
+    entry.flag = flag;
+
+    table_[index(key)] = entry;
 }
 
 


### PR DESCRIPTION
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 16MB, UHO_Lichess_4852_v1.epd):
Elo: 21.19 +/- 9.14, nElo: 32.66 +/- 14.05
LOS: 100.00 %, DrawRatio: 42.67 %, PairsRatio: 1.41
Games: 2348, Wins: 702, Losses: 559, Draws: 1087, Points: 1245.5 (53.05 %)
Ptnml(0-2): [41, 238, 501, 325, 69], WL/DD Ratio: 0.91
LLR: 2.90 (100.4%) (-2.25, 2.89) [0.00, 5.00]
--------------------------------------------------
20165274 nodes 5903183 nps