### PR TITLE
Cutnode negext

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -398,8 +398,11 @@ i32 Raphael::negamax(
                     extension = 2;  // double extensions
                 else
                     extension = 1;  // singular extensions
-            } else if (ttentry.score >= beta)
+            } else if (ttentry.score >= beta) {
                 extension = -1;  // negative extensions
+            } else if (cutnode) {
+                extension = -1;  // cutnode negative extensions
+            }
         }
 
         tt_.prefetch(board.hash_after<false>(move));


### PR DESCRIPTION
```
Elo   | 2.88 +- 2.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 29766 W: 7499 L: 7252 D: 15015
Penta | [390, 3544, 6802, 3723, 424]
```
https://rmeguro.pythonanywhere.com/test/25/


bench: 10804670
