### PR TITLE
feat: store to tt in qsearch

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -544,6 +544,8 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
 
     // search
     i32 bestscore = static_eval;
+    chess::Move bestmove = chess::Move::NO_MOVE;
+    auto ttflag = tt_.UPPER;
 
     const i32 futility = bestscore + QS_FUTILITY_MARGIN;
 
@@ -571,10 +573,19 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
 
             if (score > alpha) {
                 alpha = score;
-                if (score >= beta) break;  // prune
+                bestmove = move;
+                ttflag = tt_.EXACT;
+
+                if (score >= beta) {
+                    ttflag = tt_.LOWER;
+                    break;  // prune}
+                }
             }
         }
     }
+
+    // update transposition table
+    if (!halt.load(memory_order_relaxed)) tt_.set(ttkey, bestscore, bestmove, 0, ttflag, ply);
 
     return bestscore;
 }

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -578,7 +578,7 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
 
                 if (score >= beta) {
                     ttflag = tt_.LOWER;
-                    break;  // prune}
+                    break;  // prune
                 }
             }
         }


### PR DESCRIPTION
Elo   | 3.29 +- 2.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21948 W: 5416 L: 5208 D: 11324
Penta | [185, 2618, 5185, 2776, 210]
https://rmeguro.pythonanywhere.com/test/95/
bench: 10637054