### PR TITLE
feat: ttmove in qsearch

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -513,7 +513,7 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
     const auto ttkey = board.hash();
     auto ttentry = TranspositionTable::ProbedEntry();
     const bool tthit = tt_.get(ttentry, ttkey, ply);
-    // const auto ttmove = ttentry.move;
+    const auto ttmove = ttentry.move;
 
     // tt cutoff
     if (!is_PV && tthit
@@ -540,7 +540,7 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
     auto& mvstack = movestack_[mvidx];
     mvstack.quietlist.clear();
     mvstack.noisylist.clear();
-    auto generator = MoveGenerator::quiescence(&mvstack.movelist, &board, &history_);
+    auto generator = MoveGenerator::quiescence(&mvstack.movelist, &board, &history_, ttmove);
 
     // search
     i32 bestscore = static_eval;

--- a/src/Raphael/movepick.cpp
+++ b/src/Raphael/movepick.cpp
@@ -19,11 +19,12 @@ MoveGenerator MoveGenerator::negamax(
 }
 
 MoveGenerator MoveGenerator::quiescence(
-    chess::MoveList<chess::ScoredMove>* movelist, const chess::Board* board, const History* history
+    chess::MoveList<chess::ScoredMove>* movelist,
+    const chess::Board* board,
+    const History* history,
+    chess::Move ttmove
 ) {
-    return MoveGenerator(
-        Stage::QS_GEN_NOISY, movelist, board, history, chess::Move::NO_MOVE, chess::Move::NO_MOVE
-    );
+    return MoveGenerator(Stage::QS_TT_MOVE, movelist, board, history, ttmove, chess::Move::NO_MOVE);
 }
 
 
@@ -132,6 +133,14 @@ chess::Move MoveGenerator::next() {
 
 
         // quiescence stages
+        case Stage::QS_TT_MOVE: {
+            stage_ = Stage::QS_GEN_NOISY;
+
+            if (ttmove_ && board_->is_legal(ttmove_)) return ttmove_;
+
+            [[fallthrough]];
+        }
+
         case Stage::QS_GEN_NOISY: {
             // generate noisy moves
             assert(movelist_->empty());
@@ -151,6 +160,8 @@ chess::Move MoveGenerator::next() {
             while (idx_ < end_) {
                 const auto idx = select_next();
                 const auto& smove = (*movelist_)[idx];
+
+                if (smove.move == ttmove_) continue;
 
                 return smove.move;
             }

--- a/src/Raphael/movepick.h
+++ b/src/Raphael/movepick.h
@@ -18,6 +18,7 @@ public:
         BAD_NOISY,
 
         // quiescence
+        QS_TT_MOVE,
         QS_GEN_NOISY,
         QS_NOISY,
     };
@@ -59,12 +60,14 @@ public:
      * \param movelist pointer to preallocated move list to use
      * \param board pointer to current board
      * \param history pointer to history table
+     * \param ttmove transposition table move
      * \returns the move generator
      */
     static MoveGenerator quiescence(
         chess::MoveList<chess::ScoredMove>* movelist,
         const chess::Board* board,
-        const History* history
+        const History* history,
+        chess::Move ttmove
     );
 
 


### PR DESCRIPTION
Elo   | 3.35 +- 2.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 20034 W: 4967 L: 4774 D: 10293
Penta | [174, 2334, 4814, 2515, 180]
https://rmeguro.pythonanywhere.com/test/99/
bench: 10507769