### PR TITLE
feat: check lmr

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -407,6 +407,9 @@ i32 Raphael::negamax(
         move_searched++;
         tm_.inc_nodes();
 
+        const auto& new_board = position_.board();
+        const bool gives_check = new_board.in_check();
+
         // principle variation search
         i32 score = INT32_MIN;
         const i32 new_depth = depth - 1 + extension;
@@ -415,6 +418,7 @@ i32 Raphael::negamax(
             i32 red_factor = LMR_TABLE[is_quiet][depth][move_searched];
             red_factor += !is_PV * LMR_NONPV;
             red_factor -= improving * LMR_IMPROVING;
+            red_factor -= gives_check * LMR_CHECK;
 
             const i32 red_depth = min(max(new_depth - red_factor / 128, 1), new_depth);
             score = -negamax<false>(

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -216,6 +216,7 @@ TunableCallback(LMR_QUIET_DIVISOR, 354, 32, 512, 12, update_lmr_table, true);
 TunableCallback(LMR_NOISY_DIVISOR, 414, 32, 512, 12, update_lmr_table, true);
 Tunable(LMR_NONPV, 130, 32, 384, 20, true);
 Tunable(LMR_IMPROVING, 128, 32, 384, 20, true);
+Tunable(LMR_CHECK, 128, 32, 384, 20, true);
 
 // quiescence
 Tunable(QS_FUTILITY_MARGIN, 150, 50, 400, 20, true);  // margin for qs futility pruning


### PR DESCRIPTION
Elo   | 3.05 +- 2.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.08 (-2.25, 2.89) [0.00, 5.00]
Games | N: 25300 W: 6278 L: 6056 D: 12966
Penta | [199, 3023, 6026, 3161, 241]
https://rmeguro.pythonanywhere.com/test/108/
bench: 12921153