### PR TITLE
feat: cutnode lmr

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -417,6 +417,7 @@ i32 Raphael::negamax(
             // late move reduction
             i32 red_factor = LMR_TABLE[is_quiet][depth][move_searched];
             red_factor += !is_PV * LMR_NONPV;
+            red_factor += cutnode * LMR_CUTNODE;
             red_factor -= improving * LMR_IMPROVING;
             red_factor -= gives_check * LMR_CHECK;
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -215,6 +215,7 @@ TunableCallback(LMR_NOISY_BASE, -30, -192, 192, 20, update_lmr_table, true);
 TunableCallback(LMR_QUIET_DIVISOR, 354, 32, 512, 12, update_lmr_table, true);
 TunableCallback(LMR_NOISY_DIVISOR, 414, 32, 512, 12, update_lmr_table, true);
 Tunable(LMR_NONPV, 130, 32, 384, 20, true);
+Tunable(LMR_CUTNODE, 128, 32, 384, 20, true);
 Tunable(LMR_IMPROVING, 128, 32, 384, 20, true);
 Tunable(LMR_CHECK, 128, 32, 384, 20, true);
 


### PR DESCRIPTION
Elo   | 2.36 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 42292 W: 10371 L: 10084 D: 21837
Penta | [367, 5031, 10077, 5290, 381]
https://rmeguro.pythonanywhere.com/test/109/
bench: 11766217