### PR TITLE
feat: history lmr

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -351,6 +351,8 @@ i32 Raphael::negamax(
 
         const bool is_quiet = board.is_quiet(move);
         const auto base_lmr = LMR_TABLE[is_quiet][depth][move_searched + 1];
+        const auto history = (is_quiet) ? history_.get_quietscore(move, board.stm())
+                                        : history_.get_noisyscore(move, board.get_captured(move));
 
         // moveloop pruning
         if (!is_root && !utils::is_loss(bestscore) && (!params_.datagen || !is_PV)) {
@@ -420,6 +422,8 @@ i32 Raphael::negamax(
             red_factor += cutnode * LMR_CUTNODE;
             red_factor -= improving * LMR_IMPROVING;
             red_factor -= gives_check * LMR_CHECK;
+            red_factor
+                -= history * 128 / ((is_quiet) ? LMR_QUIET_HIST_DIVISOR : LMR_NOISY_HIST_DIVISOR);
 
             const i32 red_depth = min(max(new_depth - red_factor / 128, 1), new_depth);
             score = -negamax<false>(

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -218,6 +218,8 @@ Tunable(LMR_NONPV, 130, 32, 384, 20, true);
 Tunable(LMR_CUTNODE, 128, 32, 384, 20, true);
 Tunable(LMR_IMPROVING, 128, 32, 384, 20, true);
 Tunable(LMR_CHECK, 128, 32, 384, 20, true);
+Tunable(LMR_QUIET_HIST_DIVISOR, 12000, 4096, 16384, 512, true);
+Tunable(LMR_NOISY_HIST_DIVISOR, 12000, 4096, 16384, 512, true);
 
 // quiescence
 Tunable(QS_FUTILITY_MARGIN, 150, 50, 400, 20, true);  // margin for qs futility pruning


### PR DESCRIPTION
Elo   | 8.65 +- 5.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5504 W: 1396 L: 1259 D: 2849
Penta | [39, 617, 1321, 718, 57]
https://rmeguro.pythonanywhere.com/test/110/
bench: 10972168

based on https://github.com/Ciekce/Stormphrax/pull/122