### PR TITLE
feat: improving rfp

### DIFF
--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -183,7 +183,7 @@ Tunable(IIR_DEPTH, 3, 3, 6, 1, true);  // min depth to apply iir from
 
 Tunable(RFP_DEPTH, 6, 1, 10, 1, true);           // max depth to apply rfp from
 Tunable(RFP_DEPTH_SCALE, 77, 25, 150, 8, true);  // margin depth scale for rfp
-Tunable(RFP_IMPROV_SCALE, 0, 0, 100, 8, true);   // margin improving scale for rfp
+Tunable(RFP_IMPROV_SCALE, 40, 0, 100, 8, true);  // margin improving scale for rfp
 
 Tunable(RAZORING_DEPTH, 4, 1, 10, 1, true);              // max depth to apply razoring from
 Tunable(RAZORING_DEPTH_SCALE, 250, 100, 350, 40, true);  // margin depth scale for razoring


### PR DESCRIPTION
Elo   | 9.20 +- 5.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4908 W: 1260 L: 1130 D: 2518
Penta | [32, 527, 1206, 657, 32]
https://rmeguro.pythonanywhere.com/test/134/
bench: 9160092