### PR TITLE
feat: node tm

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -173,7 +173,7 @@ Raphael::MoveScore Raphael::get_move(const i32 t_remain, const i32 t_inc, atomic
         if (ucilevel_ == UciInfoLevel::ALL) print_uci_info(depth, score, ss);
 
         // soft limit
-        if (tm_.is_soft_limit_reached(halt, depth)) break;
+        if (tm_.is_soft_limit_reached(halt, bestmove, depth)) break;
     }
 
     // last attempt to get bestmove
@@ -403,6 +403,8 @@ i32 Raphael::negamax(
             }
         }
 
+        const u64 old_nodes = tm_.get_nodes();
+
         tt_.prefetch(board.hash_after<false>(move));
         position_.make_move(move);
         ss->move = move;
@@ -446,6 +448,8 @@ i32 Raphael::negamax(
         assert(score != INT32_MIN);
 
         position_.unmake_move();
+
+        if (is_root) tm_.inc_nodes(move, tm_.get_nodes() - old_nodes);
 
         if (score > bestscore) {
             bestscore = score;

--- a/src/Raphael/tm.cpp
+++ b/src/Raphael/tm.cpp
@@ -1,10 +1,13 @@
 #include <Raphael/tm.h>
 #include <Raphael/tunable.h>
 
+#include <cstring>
+
 using namespace raphael;
 using std::atomic;
 using std::max;
 using std::memory_order_relaxed;
+using std::memset;
 using std::min;
 namespace ch = std::chrono;
 
@@ -68,7 +71,15 @@ i64 TimeManager::get_time() const {
 
 void TimeManager::inc_nodes() { nodes_++; }
 
+void TimeManager::inc_nodes(chess::Move move, u64 count) {
+    nodes_per_move_[move.from()][move.to()] += count;
+}
+
 u64 TimeManager::get_nodes() const { return nodes_; }
+
+u64 TimeManager::get_nodes(chess::Move move) const {
+    return nodes_per_move_[move.from()][move.to()];
+}
 
 
 bool TimeManager::is_hard_limit_reached(atomic<bool>& halt) const {
@@ -87,7 +98,7 @@ bool TimeManager::is_hard_limit_reached(atomic<bool>& halt) const {
     return halt.load(memory_order_relaxed);
 }
 
-bool TimeManager::is_soft_limit_reached(atomic<bool>& halt, i32 depth) const {
+bool TimeManager::is_soft_limit_reached(atomic<bool>& halt, chess::Move bestmove, i32 depth) const {
     // if soft nodes is specified, check node count
     if (soft_nodes_.has_value() && nodes_ >= *soft_nodes_) {
         halt.store(true, memory_order_relaxed);
@@ -102,7 +113,7 @@ bool TimeManager::is_soft_limit_reached(atomic<bool>& halt, i32 depth) const {
 
     // if soft time is specified, check against the adjusted time
     if (soft_t_.has_value()) {
-        const auto soft_t_adj = adjust_soft_time();
+        const auto soft_t_adj = adjust_soft_time(bestmove);
         if (get_time() >= soft_t_adj) {
             halt.store(true, memory_order_relaxed);
             return true;
@@ -115,6 +126,7 @@ bool TimeManager::is_soft_limit_reached(atomic<bool>& halt, i32 depth) const {
 
 void TimeManager::reset() {
     nodes_ = 0;
+    memset(nodes_per_move_, 0, sizeof(nodes_per_move_));
     hard_t_.reset();
     soft_t_.reset();
     hard_nodes_.reset();
@@ -123,7 +135,12 @@ void TimeManager::reset() {
 }
 
 
-i64 TimeManager::adjust_soft_time() const {
+i64 TimeManager::adjust_soft_time(chess::Move bestmove) const {
     assert(soft_t_.has_value());
-    return *soft_t_;  // no adjustments for now
+
+    // node tm
+    const auto ratio = f64(get_nodes(bestmove)) / f64(get_nodes());
+    const auto node_tm_factor = (NODE_TM_BASE / 100.0) - (NODE_TM_SCALE * ratio / 100.0);
+
+    return i64(*soft_t_ * node_tm_factor);
 }

--- a/src/Raphael/tm.h
+++ b/src/Raphael/tm.h
@@ -21,6 +21,7 @@ public:
 private:
     std::chrono::time_point<std::chrono::steady_clock> start_t_;  // search start time
     u64 nodes_;
+    u64 nodes_per_move_[64][64];
 
     std::optional<i64> hard_t_;  // hard time limit, checked every few nodes
     std::optional<i64> soft_t_;  // soft time limit, checked after each iterative deepening
@@ -53,8 +54,25 @@ public:
     /** Increments the node counter */
     void inc_nodes();
 
-    /** Returns the number of nodes visited */
+    /** Increments the node counter for a certain move
+     *
+     * \param move move to increment for
+     * \param count amount to increment by
+     */
+    void inc_nodes(chess::Move move, u64 count);
+
+    /** Returns the number of nodes visited
+     *
+     * \returns number of nodes visited
+     */
     u64 get_nodes() const;
+
+    /** Returns the number of nodes visited for a certain move
+     *
+     * \param move move to get node count for
+     * \returns number of nodes visited for that move
+     */
+    u64 get_nodes(chess::Move move) const;
 
 
     /** Sets halt and returns its value if the hard limit is reached
@@ -68,17 +86,22 @@ public:
      * Checked at the end of a search at `depth`
      *
      * \param halt bool reference which will turn false to indicate search should stop
+     * \param bestmove current bestmove
      * \param depth the current search depth
      * \returns the new value of halt
      */
-    bool is_soft_limit_reached(std::atomic<bool>& halt, i32 depth) const;
+    bool is_soft_limit_reached(std::atomic<bool>& halt, chess::Move bestmove, i32 depth) const;
 
 private:
     /** Resets the time manager */
     void reset();
 
 
-    /** Computes the adjusted soft time limit */
-    i64 adjust_soft_time() const;
+    /** Computes the adjusted soft time limit
+     *
+     * \param bestmove current bestmove
+     * \returns the new soft time limit
+     */
+    i64 adjust_soft_time(chess::Move bestmove) const;
 };
 }  // namespace raphael

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -189,7 +189,7 @@ Tunable(HARD_TIME_FACTOR, 200, 150, 250, true);  // percentage of base time to u
 Tunable(SOFT_TIME_FACTOR, 70, 50, 100, true);    // percentage of base time to use as soft time
 
 Tunable(NODE_TM_DEPTH, 5, 3, 10, true);       // min depth for node tm
-Tunable(NODE_TM_BASE, 250, 150, 300, true);   // base soft tm scale for node tm
+Tunable(NODE_TM_BASE, 200, 150, 300, true);   // base soft tm scale for node tm
 Tunable(NODE_TM_SCALE, 150, 100, 200, true);  // ratio scale of soft tm scale for node tm
 
 // search

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -188,6 +188,10 @@ Tunable(INC_FACTOR, 80, 50, 100, true);  // percentage of increment to use use a
 Tunable(HARD_TIME_FACTOR, 200, 150, 250, true);  // percentage of base time to use as hard time
 Tunable(SOFT_TIME_FACTOR, 70, 50, 100, true);    // percentage of base time to use as soft time
 
+Tunable(NODE_TM_DEPTH, 5, 3, 10, true);       // min depth for node tm
+Tunable(NODE_TM_BASE, 250, 150, 300, true);   // base soft tm scale for node tm
+Tunable(NODE_TM_SCALE, 150, 100, 200, true);  // ratio scale of soft tm scale for node tm
+
 // search
 Tunable(ASPIRATION_DEPTH, 3, 2, 5, true);              // min depth to apply aspiration windows
 Tunable(ASPIRATION_INIT_SIZE, 50, 5, 100, true);       // initial window size


### PR DESCRIPTION
stc
```
Elo   | 15.01 +- 6.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2826 W: 731 L: 609 D: 1486
Penta | [12, 276, 734, 360, 31]
```
https://rmeguro.pythonanywhere.com/test/140/

ltc
```
Elo   | 10.14 +- 5.39 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3940 W: 948 L: 833 D: 2159
Penta | [6, 408, 1025, 527, 4]
```
https://rmeguro.pythonanywhere.com/test/142/