### PR TITLE
feat: bestmove stability tm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,6 +228,7 @@ SFML-*/
 fastchess
 texel-tuner
 weather-factory
+enginetest
 bullet
 
 # Chess Games

--- a/src/Raphael/tm.cpp
+++ b/src/Raphael/tm.cpp
@@ -98,7 +98,7 @@ bool TimeManager::is_hard_limit_reached(atomic<bool>& halt) const {
     return halt.load(memory_order_relaxed);
 }
 
-bool TimeManager::is_soft_limit_reached(atomic<bool>& halt, chess::Move bestmove, i32 depth) const {
+bool TimeManager::is_soft_limit_reached(atomic<bool>& halt, chess::Move bestmove, i32 depth) {
     // if soft nodes is specified, check node count
     if (soft_nodes_.has_value() && nodes_ >= *soft_nodes_) {
         halt.store(true, memory_order_relaxed);
@@ -132,12 +132,28 @@ void TimeManager::reset() {
     hard_nodes_.reset();
     soft_nodes_.reset();
     max_depth_.reset();
+    prev_bestmove_ = chess::Move::NO_MOVE;
+    bestmove_stability_ = 0;
 }
 
 
-i64 TimeManager::adjust_soft_time(chess::Move bestmove, i32 depth) const {
+i64 TimeManager::adjust_soft_time(chess::Move bestmove, i32 depth) {
     assert(soft_t_.has_value());
     f64 factor = 1.0;
+
+    // stability tm
+    if (bestmove == prev_bestmove_)
+        bestmove_stability_++;
+    else
+        bestmove_stability_ = 0;
+    prev_bestmove_ = bestmove;
+
+    if (depth >= MOVE_STABILITY_TM_DEPTH)
+        factor *= max(
+            (MOVE_STABILITY_TM_BASE / 100.0)
+                - (MOVE_STABILITY_TM_SCALE * bestmove_stability_ / 100.0),
+            (MOVE_STABILITY_TM_MIN / 100.0)
+        );
 
     // node tm
     if (depth >= NODE_TM_DEPTH) {

--- a/src/Raphael/tm.h
+++ b/src/Raphael/tm.h
@@ -31,6 +31,9 @@ private:
 
     std::optional<i32> max_depth_;  // max depth
 
+    chess::Move prev_bestmove_;
+    i32 bestmove_stability_;
+
 
 public:
     TimeManager();
@@ -90,7 +93,7 @@ public:
      * \param depth the current search depth
      * \returns the new value of halt
      */
-    bool is_soft_limit_reached(std::atomic<bool>& halt, chess::Move bestmove, i32 depth) const;
+    bool is_soft_limit_reached(std::atomic<bool>& halt, chess::Move bestmove, i32 depth);
 
 private:
     /** Resets the time manager */
@@ -103,6 +106,6 @@ private:
      * \param depth the current search depth
      * \returns the new soft time limit
      */
-    i64 adjust_soft_time(chess::Move bestmove, i32 depth) const;
+    i64 adjust_soft_time(chess::Move bestmove, i32 depth);
 };
 }  // namespace raphael

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -189,7 +189,7 @@ Tunable(HARD_TIME_FACTOR, 200, 150, 250, true);  // percentage of base time to u
 Tunable(SOFT_TIME_FACTOR, 70, 50, 100, true);    // percentage of base time to use as soft time
 
 Tunable(MOVE_STABILITY_TM_DEPTH, 5, 3, 10, true);      // min depth for move stability tm
-Tunable(MOVE_STABILITY_TM_BASE, 180, 100, 300, true);  // base soft limit for move stability tm
+Tunable(MOVE_STABILITY_TM_BASE, 150, 100, 300, true);  // base soft limit for move stability tm
 Tunable(MOVE_STABILITY_TM_SCALE, 10, 0, 50, true);     // soft limit scale for move stability tm
 Tunable(MOVE_STABILITY_TM_MIN, 90, 50, 100, true);     // min soft limit for move stability tm
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -189,8 +189,8 @@ Tunable(HARD_TIME_FACTOR, 200, 150, 250, true);  // percentage of base time to u
 Tunable(SOFT_TIME_FACTOR, 70, 50, 100, true);    // percentage of base time to use as soft time
 
 Tunable(MOVE_STABILITY_TM_DEPTH, 5, 3, 10, true);      // min depth for move stability tm
-Tunable(MOVE_STABILITY_TM_BASE, 150, 100, 300, true);  // base soft limit for move stability tm
-Tunable(MOVE_STABILITY_TM_SCALE, 10, 0, 50, true);     // soft limit scale for move stability tm
+Tunable(MOVE_STABILITY_TM_BASE, 130, 100, 300, true);  // base soft limit for move stability tm
+Tunable(MOVE_STABILITY_TM_SCALE, 5, 0, 50, true);      // soft limit scale for move stability tm
 Tunable(MOVE_STABILITY_TM_MIN, 90, 50, 100, true);     // min soft limit for move stability tm
 
 Tunable(NODE_TM_DEPTH, 5, 3, 10, true);       // min depth for node tm

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -189,9 +189,9 @@ Tunable(HARD_TIME_FACTOR, 200, 150, 250, true);  // percentage of base time to u
 Tunable(SOFT_TIME_FACTOR, 70, 50, 100, true);    // percentage of base time to use as soft time
 
 Tunable(MOVE_STABILITY_TM_DEPTH, 5, 3, 10, true);      // min depth for move stability tm
-Tunable(MOVE_STABILITY_TM_BASE, 130, 100, 300, true);  // base soft limit for move stability tm
+Tunable(MOVE_STABILITY_TM_BASE, 120, 100, 300, true);  // base soft limit for move stability tm
 Tunable(MOVE_STABILITY_TM_SCALE, 5, 0, 50, true);      // soft limit scale for move stability tm
-Tunable(MOVE_STABILITY_TM_MIN, 90, 50, 100, true);     // min soft limit for move stability tm
+Tunable(MOVE_STABILITY_TM_MIN, 80, 50, 100, true);     // min soft limit for move stability tm
 
 Tunable(NODE_TM_DEPTH, 5, 3, 10, true);       // min depth for node tm
 Tunable(NODE_TM_BASE, 200, 100, 300, true);   // base soft limit for node tm

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -189,9 +189,9 @@ Tunable(HARD_TIME_FACTOR, 200, 150, 250, true);  // percentage of base time to u
 Tunable(SOFT_TIME_FACTOR, 70, 50, 100, true);    // percentage of base time to use as soft time
 
 Tunable(MOVE_STABILITY_TM_DEPTH, 5, 3, 10, true);      // min depth for move stability tm
-Tunable(MOVE_STABILITY_TM_BASE, 150, 100, 300, true);  // base soft limit for move stability tm
+Tunable(MOVE_STABILITY_TM_BASE, 120, 100, 300, true);  // base soft limit for move stability tm
 Tunable(MOVE_STABILITY_TM_SCALE, 5, 0, 50, true);      // soft limit scale for move stability tm
-Tunable(MOVE_STABILITY_TM_MIN, 90, 50, 100, true);     // min soft limit for move stability tm
+Tunable(MOVE_STABILITY_TM_MIN, 80, 50, 100, true);     // min soft limit for move stability tm
 
 Tunable(NODE_TM_DEPTH, 5, 3, 10, true);       // min depth for node tm
 Tunable(NODE_TM_BASE, 200, 100, 300, true);   // base soft limit for node tm

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -189,9 +189,9 @@ Tunable(HARD_TIME_FACTOR, 200, 150, 250, true);  // percentage of base time to u
 Tunable(SOFT_TIME_FACTOR, 70, 50, 100, true);    // percentage of base time to use as soft time
 
 Tunable(MOVE_STABILITY_TM_DEPTH, 5, 3, 10, true);      // min depth for move stability tm
-Tunable(MOVE_STABILITY_TM_BASE, 120, 100, 300, true);  // base soft limit for move stability tm
+Tunable(MOVE_STABILITY_TM_BASE, 150, 100, 300, true);  // base soft limit for move stability tm
 Tunable(MOVE_STABILITY_TM_SCALE, 5, 0, 50, true);      // soft limit scale for move stability tm
-Tunable(MOVE_STABILITY_TM_MIN, 80, 50, 100, true);     // min soft limit for move stability tm
+Tunable(MOVE_STABILITY_TM_MIN, 90, 50, 100, true);     // min soft limit for move stability tm
 
 Tunable(NODE_TM_DEPTH, 5, 3, 10, true);       // min depth for node tm
 Tunable(NODE_TM_BASE, 200, 100, 300, true);   // base soft limit for node tm

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -188,6 +188,11 @@ Tunable(INC_FACTOR, 80, 50, 100, true);  // percentage of increment to use use a
 Tunable(HARD_TIME_FACTOR, 200, 150, 250, true);  // percentage of base time to use as hard time
 Tunable(SOFT_TIME_FACTOR, 70, 50, 100, true);    // percentage of base time to use as soft time
 
+Tunable(MOVE_STABILITY_TM_DEPTH, 5, 3, 10, true);      // min depth for move stability tm
+Tunable(MOVE_STABILITY_TM_BASE, 180, 100, 300, true);  // base soft limit for move stability tm
+Tunable(MOVE_STABILITY_TM_SCALE, 10, 0, 50, true);     // soft limit scale for move stability tm
+Tunable(MOVE_STABILITY_TM_MIN, 90, 50, 100, true);     // min soft limit for move stability tm
+
 Tunable(NODE_TM_DEPTH, 5, 3, 10, true);       // min depth for node tm
 Tunable(NODE_TM_BASE, 200, 100, 300, true);   // base soft limit for node tm
 Tunable(NODE_TM_SCALE, 150, 100, 200, true);  // soft limit scale for node tm


### PR DESCRIPTION
scalinggggggggggggggggggggggggg

stc
```
Elo   | 2.39 +- 1.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 34776 W: 8190 L: 7951 D: 18635
Penta | [195, 3949, 8877, 4156, 211]
```
https://rmeguro.pythonanywhere.com/test/149/

ltc
```
Elo   | 4.17 +- 3.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11986 W: 2709 L: 2565 D: 6712
Penta | [24, 1302, 3204, 1432, 31]
```
https://rmeguro.pythonanywhere.com/test/151/
