### PR TITLE
Eval stability tm

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The engine contains the following features:
   - [x] Hard/soft limit                     (`v3.0+`)
   - [x] Node-based scaling                  (`v3.2+`)
   - [x] Bestmove stability                  (`v3.2+`)
-  - [ ] Score stability
+  - [x] Score stability                     (`v3.2+`)
   - [ ] Complexity
 - [x] Pondering                             (`v1.2+`)
 - [x] Performance                           (`v1.8+`)

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The engine contains the following features:
 - [x] Time management                       (`v1.0+`)
   - [x] Hard/soft limit                     (`v3.0+`)
   - [x] Node-based scaling                  (`v3.2+`)
-  - [ ] Bestmove stability
+  - [x] Bestmove stability                  (`v3.2+`)
   - [ ] Score stability
   - [ ] Complexity
 - [x] Pondering                             (`v1.2+`)

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -173,7 +173,7 @@ Raphael::MoveScore Raphael::get_move(const i32 t_remain, const i32 t_inc, atomic
         if (ucilevel_ == UciInfoLevel::ALL) print_uci_info(depth, score, ss);
 
         // soft limit
-        if (tm_.is_soft_limit_reached(halt, bestmove, depth)) break;
+        if (tm_.is_soft_limit_reached(halt, bestmove, score, depth)) break;
     }
 
     // last attempt to get bestmove

--- a/src/Raphael/tm.cpp
+++ b/src/Raphael/tm.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 
 using namespace raphael;
+using std::abs;
 using std::atomic;
 using std::max;
 using std::memory_order_relaxed;
@@ -98,7 +99,9 @@ bool TimeManager::is_hard_limit_reached(atomic<bool>& halt) const {
     return halt.load(memory_order_relaxed);
 }
 
-bool TimeManager::is_soft_limit_reached(atomic<bool>& halt, chess::Move bestmove, i32 depth) {
+bool TimeManager::is_soft_limit_reached(
+    atomic<bool>& halt, chess::Move bestmove, i32 score, i32 depth
+) {
     // if soft nodes is specified, check node count
     if (soft_nodes_.has_value() && nodes_ >= *soft_nodes_) {
         halt.store(true, memory_order_relaxed);
@@ -113,7 +116,7 @@ bool TimeManager::is_soft_limit_reached(atomic<bool>& halt, chess::Move bestmove
 
     // if soft time is specified, check against the adjusted time
     if (soft_t_.has_value()) {
-        const auto soft_t_adj = adjust_soft_time(bestmove, depth);
+        const auto soft_t_adj = adjust_soft_time(bestmove, score, depth);
         if (get_time() >= soft_t_adj) {
             halt.store(true, memory_order_relaxed);
             return true;
@@ -134,14 +137,16 @@ void TimeManager::reset() {
     max_depth_.reset();
     prev_bestmove_ = chess::Move::NO_MOVE;
     bestmove_stability_ = 0;
+    prev_score_ = 0;
+    score_stability_ = 0;
 }
 
 
-i64 TimeManager::adjust_soft_time(chess::Move bestmove, i32 depth) {
+i64 TimeManager::adjust_soft_time(chess::Move bestmove, i32 score, i32 depth) {
     assert(soft_t_.has_value());
     f64 factor = 1.0;
 
-    // stability tm
+    // move stability tm
     if (bestmove == prev_bestmove_)
         bestmove_stability_++;
     else
@@ -153,6 +158,20 @@ i64 TimeManager::adjust_soft_time(chess::Move bestmove, i32 depth) {
             (MOVE_STABILITY_TM_BASE / 100.0)
                 - (MOVE_STABILITY_TM_SCALE * bestmove_stability_ / 100.0),
             (MOVE_STABILITY_TM_MIN / 100.0)
+        );
+
+    // score stability tm
+    if (abs(score - prev_score_) <= SCORE_STABILITY_MARGIN)
+        score_stability_++;
+    else
+        score_stability_ = 0;
+    prev_score_ = score;
+
+    if (depth >= SCORE_STABILITY_TM_DEPTH)
+        factor *= max(
+            (SCORE_STABILITY_TM_BASE / 100.0)
+                - (SCORE_STABILITY_TM_SCALE * score_stability_ / 100.0),
+            (SCORE_STABILITY_TM_MIN / 100.0)
         );
 
     // node tm

--- a/src/Raphael/tm.h
+++ b/src/Raphael/tm.h
@@ -34,6 +34,9 @@ private:
     chess::Move prev_bestmove_;
     i32 bestmove_stability_;
 
+    i32 prev_score_;
+    i32 score_stability_;
+
 
 public:
     TimeManager();
@@ -90,10 +93,11 @@ public:
      *
      * \param halt bool reference which will turn false to indicate search should stop
      * \param bestmove current bestmove
-     * \param depth the current search depth
+     * \param score current score
+     * \param depth current search depth
      * \returns the new value of halt
      */
-    bool is_soft_limit_reached(std::atomic<bool>& halt, chess::Move bestmove, i32 depth);
+    bool is_soft_limit_reached(std::atomic<bool>& halt, chess::Move bestmove, i32 score, i32 depth);
 
 private:
     /** Resets the time manager */
@@ -103,9 +107,10 @@ private:
     /** Computes the adjusted soft time limit
      *
      * \param bestmove current bestmove
-     * \param depth the current search depth
+     * \param score current score
+     * \param depth current search depth
      * \returns the new soft time limit
      */
-    i64 adjust_soft_time(chess::Move bestmove, i32 depth);
+    i64 adjust_soft_time(chess::Move bestmove, i32 score, i32 depth);
 };
 }  // namespace raphael

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -193,6 +193,12 @@ Tunable(MOVE_STABILITY_TM_BASE, 120, 100, 300, true);  // base soft limit for mo
 Tunable(MOVE_STABILITY_TM_SCALE, 5, 0, 50, true);      // soft limit scale for move stability tm
 Tunable(MOVE_STABILITY_TM_MIN, 80, 50, 100, true);     // min soft limit for move stability tm
 
+Tunable(SCORE_STABILITY_MARGIN, 10, 1, 50, true);       // distance to last score to raise stability
+Tunable(SCORE_STABILITY_TM_DEPTH, 5, 3, 10, true);      // min depth for score stability tm
+Tunable(SCORE_STABILITY_TM_BASE, 120, 100, 300, true);  // base soft limit for score stability tm
+Tunable(SCORE_STABILITY_TM_SCALE, 5, 0, 50, true);      // soft limit scale for score stability tm
+Tunable(SCORE_STABILITY_TM_MIN, 80, 50, 100, true);     // min soft limit for score stability tm
+
 Tunable(NODE_TM_DEPTH, 5, 3, 10, true);       // min depth for node tm
 Tunable(NODE_TM_BASE, 200, 100, 300, true);   // base soft limit for node tm
 Tunable(NODE_TM_SCALE, 150, 100, 200, true);  // soft limit scale for node tm


### PR DESCRIPTION
stc
```
Elo   | 3.60 +- 2.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 16614 W: 3921 L: 3749 D: 8944
Penta | [99, 1828, 4269, 2024, 87]
```
https://rmeguro.pythonanywhere.com/test/153/

ltc
```
Elo   | 2.85 +- 2.29 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21104 W: 4772 L: 4599 D: 11733
Penta | [49, 2241, 5799, 2414, 49]
```
https://rmeguro.pythonanywhere.com/test/155/
