### PR TITLE
feat: softcap total conthist for different plies

### DIFF
--- a/src/Raphael/History.cpp
+++ b/src/Raphael/History.cpp
@@ -20,6 +20,12 @@ void HistoryEntry::update(i32 bonus) {
     value += bonus - value * abs(bonus) / HISTORY_MAX;
 }
 
+void HistoryEntry::update_with_base(i32 bonus, i32 base) {
+    assert(bonus >= -HISTORY_MAX);
+    assert(bonus <= HISTORY_MAX);
+    value += bonus - base * abs(bonus) / HISTORY_MAX;
+}
+
 
 
 History::History(): butterfly_hist_{}, capt_hist_{} {}
@@ -54,10 +60,15 @@ void History::update_quiet(chess::Move move, const Position<true>& position, i32
     const auto prev2 = position.prev_move(2);
     const auto prev4 = position.prev_move(4);
 
+    const auto total_conthist = get_conthist(move, position);
+
     butterfly_entry(move, stm).update(bonus);
-    if (prev1.moving != chess::Piece::NONE) cont_entry(move, moving, prev1).update(bonus);
-    if (prev2.moving != chess::Piece::NONE) cont_entry(move, moving, prev2).update(bonus);
-    if (prev4.moving != chess::Piece::NONE) cont_entry(move, moving, prev4).update(bonus);
+    if (prev1.moving != chess::Piece::NONE)
+        cont_entry(move, moving, prev1).update_with_base(bonus, total_conthist);
+    if (prev2.moving != chess::Piece::NONE)
+        cont_entry(move, moving, prev2).update_with_base(bonus, total_conthist);
+    if (prev4.moving != chess::Piece::NONE)
+        cont_entry(move, moving, prev4).update_with_base(bonus, total_conthist);
 }
 
 void History::update_noisy(chess::Move move, chess::Piece captured, i32 bonus) {
@@ -65,16 +76,14 @@ void History::update_noisy(chess::Move move, chess::Piece captured, i32 bonus) {
 }
 
 
-i32 History::get_quietscore(chess::Move move, const Position<true>& position) const {
+i32 History::get_conthist(chess::Move move, const Position<true>& position) const {
     const auto& board = position.board();
-    const auto stm = board.stm();
     const auto moving = board.at(move.from());
     const auto prev1 = position.prev_move(1);
     const auto prev2 = position.prev_move(2);
     const auto prev4 = position.prev_move(4);
 
     i32 score = 0;
-    score += butterfly_entry(move, stm);
     score += (prev1.moving != chess::Piece::NONE)
                  ? cont_entry(move, moving, prev1) * CONTHIST1_WEIGHT / 128
                  : 0;
@@ -84,6 +93,16 @@ i32 History::get_quietscore(chess::Move move, const Position<true>& position) co
     score += (prev4.moving != chess::Piece::NONE)
                  ? cont_entry(move, moving, prev4) * CONTHIST4_WEIGHT / 128
                  : 0;
+    return score;
+}
+
+i32 History::get_quietscore(chess::Move move, const Position<true>& position) const {
+    const auto& board = position.board();
+    const auto stm = board.stm();
+
+    i32 score = 0;
+    score += butterfly_entry(move, stm);
+    score += get_conthist(move, position);
     return score;
 }
 

--- a/src/Raphael/History.h
+++ b/src/Raphael/History.h
@@ -14,6 +14,13 @@ struct HistoryEntry {
      * \param bonus bonus to apply, negative to apply penalty
      */
     void update(i32 bonus);
+
+    /** Updates the entry with gravity from a base
+     *
+     * \param bonus bonus to apply, negative to apply penalty
+     * \param base base value (in normal update, base = current val)
+     */
+    void update_with_base(i32 bonus, i32 base);
 };
 
 
@@ -74,6 +81,14 @@ public:
      */
     void update_noisy(chess::Move move, chess::Piece captured, i32 bonus);
 
+
+    /** Returns the continuation history score
+     *
+     * \param move quiet move
+     * \param position current position
+     * \returns continuation history score
+     */
+    i32 get_conthist(chess::Move move, const Position<true>& position) const;
 
     /** Returns the quiet history score
      *


### PR DESCRIPTION
Based on:
- https://github.com/Ciekce/Stormphrax/pull/267/changes
- https://github.com/Yoshie2000/PlentyChess/pull/38/changes

```
Elo   | 6.55 +- 4.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7532 W: 1808 L: 1666 D: 4058
Penta | [37, 866, 1832, 980, 51]
```
https://rmeguro.pythonanywhere.com/test/158/

bench: 9119991