### PR TITLE
feat: lmp in qsearch

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -569,6 +569,9 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
     i32 move_searched = 0;
     while (const auto move = generator.next()) {
         if (!utils::is_loss(bestscore)) {
+            // qs late move pruning
+            if (move_searched >= QS_MAX_MOVES) break;
+
             // qs futility pruning
             if (!in_check && futility <= alpha && !SEE::see(move, board, 1)) {
                 bestscore = max(bestscore, futility);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -254,6 +254,7 @@ Tunable(LMR_QUIET_HIST_DIVISOR, 12000, 4096, 16384, true);
 Tunable(LMR_NOISY_HIST_DIVISOR, 12000, 4096, 16384, true);
 
 // quiescence
+Tunable(QS_MAX_MOVES, 3, 1, 5, true);             // max moves to search in qsearch
 Tunable(QS_FUTILITY_MARGIN, 150, 50, 400, true);  // margin for qs futility pruning
 Tunable(QS_SEE_THRESH, -100, -500, 200, true);    // SEE threshold for qs SEE pruning
 


### PR DESCRIPTION
```
Elo   | 5.07 +- 3.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9944 W: 2333 L: 2188 D: 5423
Penta | [45, 1144, 2457, 1273, 53]
```
https://rmeguro.pythonanywhere.com/test/162/
bench: 10773507