### PR TITLE
feat: pawn correction history

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The engine contains the following features:
     - [x] Continuation history              (`v3.2+`)
     - [x] Threats in history                (`v3.2+`)
     - [x] SEE                               (`v1.7+`)
-    - [ ] Pawn correction history
+    - [x] Pawn correction history           (`v3.3+`)
     - [ ] Major piece correction history
     - [ ] Nonpawn correction history
     - [ ] Continuation correction history

--- a/src/Raphael/History.cpp
+++ b/src/Raphael/History.cpp
@@ -1,5 +1,4 @@
 #include <Raphael/History.h>
-#include <Raphael/tunable.h>
 #include <Raphael/utils.h>
 
 #include <algorithm>
@@ -27,8 +26,17 @@ void HistoryEntry::update_with_base(i32 bonus, i32 base) {
 }
 
 
+CorrectionEntry::operator i32() const { return value; }
 
-History::History(): butterfly_hist_{}, cont_hist_{}, capt_hist_{} {}
+void CorrectionEntry::update(i32 bonus) {
+    assert(bonus >= -CORRHIST_MAX);
+    assert(bonus <= CORRHIST_MAX);
+    value += bonus - value * abs(bonus) / CORRHIST_MAX;
+}
+
+
+
+History::History(): butterfly_hist_{}, cont_hist_{}, capt_hist_{}, pawn_correction_{} {}
 
 
 i32 History::quiet_bonus(i32 depth) const {
@@ -111,10 +119,29 @@ i32 History::get_noisyscore(chess::Move move, chess::Piece captured) const {
 }
 
 
+void History::update_corrections(const chess::Board& board, i32 depth, i32 score, i32 static_eval) {
+    const auto bonus = clamp(
+        (score - static_eval) * depth / CORRHIST_BONUS_DEPTH_DIVISOR,
+        -CORRHIST_BONUS_MAX,
+        CORRHIST_BONUS_MAX
+    );
+    pawn_corr_entry(board).update(bonus);
+}
+
+i32 History::correct(const chess::Board& board, i32 score) const {
+    i32 correction = 0;
+    correction += pawn_corr_entry(board) * PAWN_CORRHIST_WEIGHT;
+    correction /= CORRHIST_MAX;
+
+    return clamp(score + correction, -MATE_SCORE + 1, MATE_SCORE - 1);
+}
+
+
 void History::clear() {
     memset(butterfly_hist_, 0, sizeof(butterfly_hist_));
     memset(cont_hist_, 0, sizeof(cont_hist_));
     memset(capt_hist_, 0, sizeof(capt_hist_));
+    memset(pawn_correction_, 0, sizeof(pawn_correction_));
 }
 
 
@@ -152,4 +179,11 @@ const HistoryEntry& History::capt_entry(chess::Move move, chess::Piece captured)
 }
 HistoryEntry& History::capt_entry(chess::Move move, chess::Piece captured) {
     return capt_hist_[move.from()][move.to()][captured];
+}
+
+const CorrectionEntry& History::pawn_corr_entry(const chess::Board& board) const {
+    return pawn_correction_[board.stm()][board.pawn_hash() % CORRHIST_SIZE];
+}
+CorrectionEntry& History::pawn_corr_entry(const chess::Board& board) {
+    return pawn_correction_[board.stm()][board.pawn_hash() % CORRHIST_SIZE];
 }

--- a/src/Raphael/History.h
+++ b/src/Raphael/History.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Raphael/position.h>
+#include <Raphael/tunable.h>
 
 
 
@@ -23,6 +24,18 @@ struct HistoryEntry {
     void update_with_base(i32 bonus, i32 base);
 };
 
+struct CorrectionEntry {
+    i16 value = 0;
+
+    operator i32() const;
+
+    /** Updates the corrhist entry with gravity
+     *
+     * \param bonus bonus to apply, negative to apply penalty
+     */
+    void update(i32 bonus);
+};
+
 
 
 class History {
@@ -30,6 +43,8 @@ private:
     HistoryEntry butterfly_hist_[64][64][2][2];  // [from][to][from attacked][to attacked]
     HistoryEntry cont_hist_[12][64][12][64];     // [prev from][prev to][from][to]
     HistoryEntry capt_hist_[64][64][13];         // [from][to][piece, 12 for non-capture queening]
+
+    CorrectionEntry pawn_correction_[2][CORRHIST_SIZE];  // [stm][pawn_hash % CORRHIST_SIZE]
 
 public:
     /** Initializes all the history tables with zeros */
@@ -107,6 +122,24 @@ public:
     i32 get_noisyscore(chess::Move move, chess::Piece captured) const;
 
 
+    /** Updates the correction histories
+     *
+     * \param board current board
+     * \param depth current depth
+     * \param score current score
+     * \param static_eval current static eval
+     */
+    void update_corrections(const chess::Board& board, i32 depth, i32 score, i32 static_eval);
+
+    /** Returns the corrected score
+     *
+     * \param board current board
+     * \param score score to correct
+     * \returns the corrected score
+     */
+    i32 correct(const chess::Board& board, i32 score) const;
+
+
     /** Zeros out all the histories */
     void clear();
 
@@ -140,5 +173,13 @@ private:
      */
     const HistoryEntry& capt_entry(chess::Move move, chess::Piece captured) const;
     HistoryEntry& capt_entry(chess::Move move, chess::Piece captured);
+
+    /** Returns a reference to the pawn corrhist entry
+     *
+     * \param board current board
+     * \returns pawn corrhist entry
+     */
+    const CorrectionEntry& pawn_corr_entry(const chess::Board& board) const;
+    CorrectionEntry& pawn_corr_entry(const chess::Board& board);
 };
 }  // namespace raphael

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -552,7 +552,7 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
     if (in_check)
         static_eval = -MATE_SCORE + ply;
     else {
-        static_eval = position_.evaluate();
+        static_eval = history_.correct(board, position_.evaluate());
 
         if (static_eval >= beta) return static_eval;
 

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -294,7 +294,8 @@ i32 Raphael::negamax(
     if (depth >= IIR_DEPTH && !ss->excluded && (is_PV || cutnode) && !ttmove) depth--;
 
     const bool in_check = board.in_check();
-    if (!ss->excluded) ss->static_eval = (in_check) ? NONE_SCORE : position_.evaluate();
+    if (!ss->excluded)
+        ss->static_eval = (in_check) ? NONE_SCORE : history_.correct(board, position_.evaluate());
     const bool improving = !in_check && ss->static_eval > (ss - 2)->static_eval;
 
     // pre-moveloop pruning
@@ -507,8 +508,14 @@ i32 Raphael::negamax(
     if (move_searched == 0) return (in_check) ? -MATE_SCORE + ply : 0;  // reward faster mate
 
     // update transposition table
-    if (!halt.load(memory_order_relaxed) && !ss->excluded)
+    if (!ss->excluded && !halt.load(memory_order_relaxed)) {
+        // update corrhist
+        if (!in_check && (bestmove == chess::Move::NO_MOVE || board.is_quiet(bestmove))
+            && (ttflag == tt_.EXACT || (ttflag == tt_.LOWER && ttentry.score > ss->static_eval)
+                || (ttflag == tt_.UPPER && ttentry.score < ss->static_eval)))
+            history_.update_corrections(board, depth, bestscore, ss->static_eval);
         tt_.set(ttkey, bestscore, bestmove, depth, ttflag, ply);
+    }
 
     return bestscore;
 }

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -511,8 +511,8 @@ i32 Raphael::negamax(
     if (!ss->excluded && !halt.load(memory_order_relaxed)) {
         // update corrhist
         if (!in_check && (bestmove == chess::Move::NO_MOVE || board.is_quiet(bestmove))
-            && (ttflag == tt_.EXACT || (ttflag == tt_.LOWER && ttentry.score > ss->static_eval)
-                || (ttflag == tt_.UPPER && ttentry.score < ss->static_eval)))
+            && (ttflag == tt_.EXACT || (ttflag == tt_.LOWER && bestscore > ss->static_eval)
+                || (ttflag == tt_.UPPER && bestscore < ss->static_eval)))
             history_.update_corrections(board, depth, bestscore, ss->static_eval);
         tt_.set(ttkey, bestscore, bestmove, depth, ttflag, ply);
     }

--- a/src/Raphael/commands.cpp
+++ b/src/Raphael/commands.cpp
@@ -2,6 +2,7 @@
 #include <Raphael/commands.h>
 
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <random>
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -291,6 +291,14 @@ Tunable(CAPTHIST_PENALTY_DEPTH_SCALE, 100, 32, 512, true);
 Tunable(CAPTHIST_PENALTY_OFFSET, 100, 32, 768, true);
 Tunable(CAPTHIST_PENALTY_MAX, 2000, 1024, 4096, true);
 
+// corrections
+static constexpr i32 CORRHIST_SIZE = 16384;
+static constexpr i32 CORRHIST_MAX = 1024;
+static constexpr i32 CORRHIST_BONUS_DEPTH_DIVISOR = 8;
+static constexpr i32 CORRHIST_BONUS_MAX = 256;
+
+Tunable(PAWN_CORRHIST_WEIGHT, 64, 32, 384, true);
+
 // commands
 static constexpr i32 BENCH_DEPTH = 14;
 

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -65,12 +65,13 @@ private:
     std::array<BitBoard, 2> pinned_ = {};          // [152] 32  pinned pieces per color
     MultiArray<BitBoard, 2, 2> castle_path_ = {};  // [184] 32  castling path for color and side
     u64 hash_ = 0;                                 // [192] 8   zobrist hash
-    CastlingRights castle_rights_ = {};            // [200] 4   allowed castling files
-    u16 plies_ = 1;                                // [200] 2   number of plies
-    u8 halfmoves_ = 0;                             // [200] 1   plies since last capture/pawn move
-    Color stm_ = Color::WHITE;                     // [200] 1   current stm
-    Square enpassant_ = Square::NONE;              // [208] 1   enpassant square
-    bool chess960_ = false;                        // [208] 1   whether chess960 is enabled
+    u64 pawn_hash_ = 0;                            // [200] 8   zobrist hash of pawns
+    CastlingRights castle_rights_ = {};            // [208] 4   allowed castling files
+    u16 plies_ = 1;                                // [208] 2   number of plies
+    u8 halfmoves_ = 0;                             // [208] 1   plies since last capture/pawn move
+    Color stm_ = Color::WHITE;                     // [208] 1   current stm
+    Square enpassant_ = Square::NONE;              // [216] 1   enpassant square
+    bool chess960_ = false;                        // [216] 1   whether chess960 is enabled
 
 
 public:
@@ -99,6 +100,7 @@ public:
     [[nodiscard]] i32 fullmoves() const { return 1 + plies_ / 2; }
 
     [[nodiscard]] u64 hash() const { return hash_; }
+    [[nodiscard]] u64 pawn_hash() const { return pawn_hash_; }
 
     [[nodiscard]] bool chess960() const { return chess960_; }
 
@@ -194,14 +196,13 @@ public:
         halfmoves_++;
         plies_++;
 
-        if (enpassant_ != Square::NONE) hash_ ^= Zobrist::enpassant(enpassant_.file());
+        if (enpassant_ != Square::NONE) update_ep_hash(enpassant_.file());
         enpassant_ = Square::NONE;
 
         if (capture) {
             remove_piece(captured, move.to());
 
             halfmoves_ = 0;
-            hash_ ^= Zobrist::piece(captured, move.to());
 
             // remove castling rights if rook is captured
             if (captured.type() == PieceType::ROOK && move.to().rank().is_back_rank(~stm_)) {
@@ -238,7 +239,7 @@ public:
                 if (ep_mask & occ(PieceType::PAWN, ~stm_)) {
                     assert(at(move.to().ep_square()) == Piece::NONE);
                     enpassant_ = move.to().ep_square();
-                    hash_ ^= Zobrist::enpassant(move.to().ep_square().file());
+                    update_ep_hash(enpassant_.file());
                 }
             }
         }
@@ -259,10 +260,6 @@ public:
 
             place_piece(king, kingto);
             place_piece(rook, rookto);
-
-            hash_ ^= Zobrist::piece(king, move.from()) ^ Zobrist::piece(king, kingto);
-            hash_ ^= Zobrist::piece(rook, move.to()) ^ Zobrist::piece(rook, rookto);
-
         } else if (move.type() == Move::PROMOTION) {
             const auto pawn = at(move.from());
             const auto prom = Piece(move.promotion_type(), stm_);
@@ -271,9 +268,6 @@ public:
 
             remove_piece(pawn, move.from());
             place_piece(prom, move.to());
-
-            hash_ ^= Zobrist::piece(pawn, move.from()) ^ Zobrist::piece(prom, move.to());
-
         } else {
             assert(at(move.from()) != Piece::NONE);
             assert(at(move.to()) == Piece::NONE);
@@ -282,8 +276,6 @@ public:
 
             remove_piece(piece, move.from());
             place_piece(piece, move.to());
-
-            hash_ ^= Zobrist::piece(piece, move.from()) ^ Zobrist::piece(piece, move.to());
         }
 
         if (move.type() == Move::ENPASSANT) {
@@ -292,8 +284,6 @@ public:
             const auto piece = Piece(PieceType::PAWN, ~stm_);
 
             remove_piece(piece, move.to().ep_square());
-
-            hash_ ^= Zobrist::piece(piece, move.to().ep_square());
         }
 
         hash_ ^= Zobrist::stm();
@@ -305,7 +295,7 @@ public:
 
     void make_nullmove() {
         hash_ ^= Zobrist::stm();
-        if (enpassant_ != Square::NONE) hash_ ^= Zobrist::enpassant(enpassant_.file());
+        if (enpassant_ != Square::NONE) update_ep_hash(enpassant_.file());
         enpassant_ = Square::NONE;
 
         plies_++;
@@ -543,7 +533,7 @@ public:
             }
         }
 
-        hash_ = compute_hash();
+        recompute_hash();
         threats_ = compute_threats();
         pinned_[Color::WHITE] = compute_pinned(Color::WHITE);
         pinned_[Color::BLACK] = compute_pinned(Color::BLACK);
@@ -635,6 +625,7 @@ private:
         plies_ = 1;
 
         hash_ = 0;
+        pawn_hash_ = 0;
     }
 
 
@@ -650,7 +641,10 @@ private:
         pieces_[pt].set(sq);
         occ_[color].set(sq);
         mailbox_[sq] = piece;
+
+        update_piece_hash(piece, sq);
     }
+
     void remove_piece(Piece piece, Square sq) {
         assert(mailbox_[sq] == piece && piece != Piece::NONE);
 
@@ -663,6 +657,38 @@ private:
         pieces_[pt].unset(sq);
         occ_[color].unset(sq);
         mailbox_[sq] = Piece::NONE;
+
+        update_piece_hash(piece, sq);
+    }
+
+
+    void update_piece_hash(Piece piece, Square sq) {
+        const auto key = Zobrist::piece(piece, sq);
+        hash_ ^= key;
+        if (piece.type() == PieceType::PAWN) pawn_hash_ ^= key;
+    }
+
+    void update_ep_hash(File file) {
+        const auto key = Zobrist::enpassant(file);
+        hash_ ^= key;
+        pawn_hash_ ^= key;
+    }
+
+    void recompute_hash() {
+        hash_ = 0;
+        pawn_hash_ = 0;
+
+        auto pieces = occ();
+        while (pieces) {
+            const auto sq = Square(pieces.poplsb());
+            update_piece_hash(at(sq), sq);
+        }
+
+        if (enpassant_ != Square::NONE) update_ep_hash(enpassant_.file());
+
+        if (stm_ == Color::WHITE) hash_ ^= Zobrist::stm();
+
+        hash_ ^= Zobrist::castling(castle_rights_.hash_index());
     }
 
 
@@ -723,28 +749,6 @@ private:
     }
 
 
-    [[nodiscard]] u64 compute_hash() const {
-        u64 hash_key = 0;
-
-        auto pieces = occ();
-        while (pieces) {
-            const auto sq = Square(pieces.poplsb());
-            hash_key ^= Zobrist::piece(at(sq), sq);
-        }
-
-        u64 ep_hash = 0;
-        if (enpassant_ != Square::NONE) ep_hash ^= Zobrist::enpassant(enpassant_.file());
-
-        u64 stm_hash = 0;
-        if (stm_ == Color::WHITE) stm_hash ^= Zobrist::stm();
-
-        u64 castling_hash = 0;
-        castling_hash ^= Zobrist::castling(castle_rights_.hash_index());
-
-        return hash_key ^ ep_hash ^ stm_hash ^ castling_hash;
-    }
-
-
     void set_castling_rights(Color color, CastlingRights::Side side, File rook_file) {
         // check the rook and king actually exists where they're supposed to
         const auto king_sq = king_square(color);
@@ -772,5 +776,5 @@ private:
     }
 };
 
-static_assert(sizeof(Board) == 208);
+static_assert(sizeof(Board) == 216);
 }  // namespace chess

--- a/src/tests/hash.cpp
+++ b/src/tests/hash.cpp
@@ -11,39 +11,46 @@ TEST_SUITE("Zobrist Hash") {
     TEST_CASE("Test Zobrist Hash Startpos") {
         Board b = Board("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
         CHECK(b.hash() == 0x463b96181691fc9c);
+        CHECK(b.pawn_hash() == 0x37FC40DA841E1692);
 
         auto mv = Move::make(Square::E2, Square::E4);
         CHECK(b.hash_after<true>(mv) == 0x823c9b50fd114196);
         CHECK(b.hash_after<false>(mv) == 0x823c9b50fd114196);
         b.make_move(mv);
         CHECK(b.hash() == 0x823c9b50fd114196);
+        CHECK(b.pawn_hash() == 0xB2D6B38C0B92E91);
 
         mv = Move::make(Square::D7, Square::D5);
         CHECK(b.hash_after<true>(mv) == 0x0756b94461c50fb0);
         CHECK(b.hash_after<false>(mv) == 0x0756b94461c50fb0);
         b.make_move(mv);
         CHECK(b.hash() == 0x0756b94461c50fb0);
+        CHECK(b.pawn_hash() == 0x76916F86F34AE5BE);
 
         mv = Move::make(Square::E4, Square::E5);
         CHECK(b.hash_after<true>(mv) == 0x662fafb965db29d4);
         CHECK(b.hash_after<false>(mv) == 0x662fafb965db29d4);
         b.make_move(mv);
         CHECK(b.hash() == 0x662fafb965db29d4);
+        CHECK(b.pawn_hash() == 0xEF3E5FD1587346D3);
 
         mv = Move::make(Square::F7, Square::F5);
         CHECK(b.hash_after<true>(mv) == 0x22a48b5a8e47ff78);
         b.make_move(mv);
         CHECK(b.hash() == 0x22a48b5a8e47ff78);
+        CHECK(b.pawn_hash() == 0x53635D981CC81576);
 
         mv = Move::make(Square::E1, Square::E2);
         CHECK(b.hash_after<true>(mv) == 0x652a607ca3f242c1);
         b.make_move(mv);
         CHECK(b.hash() == 0x652a607ca3f242c1);
+        CHECK(b.pawn_hash() == 0x83871FE249DCEE04);
 
         mv = Move::make(Square::E8, Square::F7);
         CHECK(b.hash_after<true>(mv) == 0x00fdd303c946bdd9);
         b.make_move(mv);
         CHECK(b.hash() == 0x00fdd303c946bdd9);
+        CHECK(b.pawn_hash() == 0x83871FE249DCEE04);
     }
 
     TEST_CASE("Test Zobrist Hash Second Position") {
@@ -53,35 +60,42 @@ TEST_SUITE("Zobrist Hash") {
         CHECK(b.hash_after<true>(mv) == 0x2DF2E8F47B022952);
         CHECK(b.hash_after<false>(mv) == 0x2DF2E8F47B022952);
         b.make_move(mv);
+        CHECK(b.pawn_hash() == 0xA4E3189C46AA4655);
 
         mv = Move::make(Square::B7, Square::B5);
         CHECK(b.hash_after<true>(mv) == 0x4DF682E1E0AF946F);
         CHECK(b.hash_after<false>(mv) == 0x4DF682E1E0AF946F);
         b.make_move(mv);
+        CHECK(b.pawn_hash() == 0x3C31542372207E61);
 
         mv = Move::make(Square::H2, Square::H4);
         CHECK(b.hash_after<true>(mv) == 0xD1551EC84B90ED11);
         CHECK(b.hash_after<false>(mv) == 0xD1551EC84B90ED11);
         b.make_move(mv);
+        CHECK(b.pawn_hash() == 0x5844EEA076388216);
 
         mv = Move::make(Square::B5, Square::B4);
         CHECK(b.hash_after<true>(mv) == 0xB0982F168A89B452);
         CHECK(b.hash_after<false>(mv) == 0xB0982F168A89B452);
         b.make_move(mv);
+        CHECK(b.pawn_hash() == 0xC15FF9D418065E5C);
 
         mv = Move::make(Square::C2, Square::C4);
         CHECK(b.hash_after<true>(mv) == 0x3C8123EA7B067637);
         b.make_move(mv);
+        CHECK(b.pawn_hash() == 0xB590D38246AE1930);
 
         CHECK(b.hash() == 0x3c8123ea7b067637);
 
         mv = Move::make<Move::ENPASSANT>(Square::B4, Square::C3);
         CHECK(b.hash_after<true>(mv) == 0x93D32682782EDFAE);
         b.make_move(mv);
+        CHECK(b.pawn_hash() == 0xE214F040EAA135A0);
 
         mv = Move::make(Square::A1, Square::A3);
         CHECK(b.hash_after<true>(mv) == 0x5c3f9b829b279560);
         b.make_move(mv);
+        CHECK(b.pawn_hash() == 0xE214F040EAA135A0);
 
         CHECK(b.hash() == 0x5c3f9b829b279560);
     }
@@ -224,9 +238,11 @@ TEST_SUITE("Zobrist Hash") {
             CHECK(b.hash_after<true>(mv) == 7868419208351108928ull);
             b.make_move(mv);
             CHECK(b.hash() == 7868419208351108928ull);
+            CHECK(b.pawn_hash() == 0x1CF5EB56432F254E);
 
             b.set_fen("rnbqkbnr/pppp1ppp/8/4pP2/8/8/PPPPP1PP/RNBQKBNR w KQkq e6 0 2");
             CHECK(b.hash() == 7868419208351108928ull);
+            CHECK(b.pawn_hash() == 0x1CF5EB56432F254E);
         }
 
         {
@@ -235,9 +251,11 @@ TEST_SUITE("Zobrist Hash") {
             CHECK(b.hash_after<true>(mv) == 14328713941299708535ull);
             b.make_move(mv);
             CHECK(b.hash() == 14328713941299708535ull);
+            CHECK(b.pawn_hash() == 0x4FC8210192F32D70);
 
             b.set_fen("rnbqkbnr/pppp1ppp/4P3/8/8/8/PPPPP1PP/RNBQKBNR b KQkq - 0 2");
             CHECK(b.hash() == 14328713941299708535ull);
+            CHECK(b.pawn_hash() == 0x4FC8210192F32D70);
         }
 
         {
@@ -246,9 +264,11 @@ TEST_SUITE("Zobrist Hash") {
             CHECK(b.hash_after<true>(mv) == 1093876600604329325ull);
             b.make_move(mv);
             CHECK(b.hash() == 1093876600604329325ull);
+            CHECK(b.pawn_hash() == 0x863FCA90C28A6A6A);
 
             b.set_fen("rnbqkbnr/pppp1ppp/8/4pP2/8/4P3/PPPP2PP/RNBQKBNR b KQkq - 0 2");
             CHECK(b.hash() == 1093876600604329325ull);
+            CHECK(b.pawn_hash() == 0x863FCA90C28A6A6A);
         }
 
         {
@@ -257,9 +277,11 @@ TEST_SUITE("Zobrist Hash") {
             CHECK(b.hash_after<true>(mv) == 2265987269840498900ull);
             b.make_move(mv);
             CHECK(b.hash() == 2265987269840498900ull);
+            CHECK(b.pawn_hash() == 0x96639702B1CE1FD3);
 
             b.set_fen("rnbqkbnr/pppp1ppp/5P2/4p3/8/8/PPPPP1PP/RNBQKBNR b KQkq - 0 2");
             CHECK(b.hash() == 2265987269840498900ull);
+            CHECK(b.pawn_hash() == 0x96639702B1CE1FD3);
         }
     }
 
@@ -270,5 +292,21 @@ TEST_SUITE("Zobrist Hash") {
         CHECK(b.hash_after<true>(Move::NULL_MOVE) == 13757846718353144213ull);
         b.make_nullmove();
         CHECK(b.hash() == 13757846718353144213ull);
+    }
+
+    TEST_CASE("Test Zobrist Hash Pawn") {
+        Board b;
+
+        b.set_fen("4k3/pppppppp/8/8/8/8/PPPPPPPP/4K3 w - - 0 1");
+        CHECK(b.pawn_hash() == 0x37FC40DA841E1692);
+
+        b.set_fen("4k3/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/4K3 w - f6 0 3");
+        CHECK(b.pawn_hash() == 0x53635D981CC81576);
+
+        b.make_nullmove();
+        CHECK(b.pawn_hash() == 0x83871FE249DCEE04);
+
+        b.set_fen("4k3/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/4K3 w - - 0 3");
+        CHECK(b.pawn_hash() == 0x83871FE249DCEE04);
     }
 }


### PR DESCRIPTION
```
Elo   | 11.27 +- 5.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3732 W: 930 L: 809 D: 1993
Penta | [12, 396, 939, 497, 22]
```
https://rmeguro.pythonanywhere.com/test/199/