### PR TITLE
feat: faster movegen

### DIFF
--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -68,7 +68,7 @@ private:
     std::array<BitBoard, 2> occ_ = {};             // [064] 16  bitboard per color
     std::array<Piece, 64> mailbox_ = {};           // [128] 64  piece on each square
     BitBoard threats_ = {};                        // [136] 16  attacked sqs by ntm (xrays stm king)
-    std::array<BitBoard, 2> pinned_ = {};          // [152] 32  pinned pieces per color
+    std::array<BitBoard, 2> pinmask_ = {};         // [152] 32  pin rays per color
     MultiArray<BitBoard, 2, 2> castle_path_ = {};  // [184] 32  castling path for color and side
     u64 hash_ = 0;                                 // [192] 8   zobrist hash
     u64 pawn_hash_ = 0;                            // [200] 8   zobrist hash of pawns
@@ -172,7 +172,9 @@ public:
 
     [[nodiscard]] BitBoard threats() const { return threats_; }
 
-    [[nodiscard]] BitBoard pinned(Color color) const { return pinned_[color]; }
+    [[nodiscard]] BitBoard pinned(Color color) const { return pinmask_[color] & occ(color); }
+
+    [[nodiscard]] BitBoard pinmask(Color color) const { return pinmask_[color]; }
 
     [[nodiscard]] bool is_attacked(Square sq, Color color) const {
         if (color == ~stm_) return threats_.is_set(sq);
@@ -299,8 +301,8 @@ public:
         hash_ ^= Zobrist::stm();
         stm_ = ~stm_;
         threats_ = compute_threats();
-        pinned_[Color::WHITE] = compute_pinned(Color::WHITE);
-        pinned_[Color::BLACK] = compute_pinned(Color::BLACK);
+        pinmask_[Color::WHITE] = compute_pinmask(Color::WHITE);
+        pinmask_[Color::BLACK] = compute_pinmask(Color::BLACK);
     }
 
     void make_nullmove() {
@@ -311,8 +313,8 @@ public:
         plies_++;
         stm_ = ~stm_;
         threats_ = compute_threats();
-        pinned_[Color::WHITE] = compute_pinned(Color::WHITE);
-        pinned_[Color::BLACK] = compute_pinned(Color::BLACK);
+        pinmask_[Color::WHITE] = compute_pinmask(Color::WHITE);
+        pinmask_[Color::BLACK] = compute_pinmask(Color::BLACK);
     }
 
 
@@ -545,8 +547,8 @@ public:
 
         recompute_hash();
         threats_ = compute_threats();
-        pinned_[Color::WHITE] = compute_pinned(Color::WHITE);
-        pinned_[Color::BLACK] = compute_pinned(Color::BLACK);
+        pinmask_[Color::WHITE] = compute_pinmask(Color::WHITE);
+        pinmask_[Color::BLACK] = compute_pinmask(Color::BLACK);
     }
 
     [[nodiscard]] std::string get_fen() const {
@@ -756,7 +758,7 @@ private:
         return threats;
     }
 
-    [[nodiscard]] BitBoard compute_pinned(Color color) const {
+    [[nodiscard]] BitBoard compute_pinmask(Color color) const {
         const auto occ_us = occ(color);
         const auto occ_opp = occ(~color);
         const auto king_sq = king_square(color);
@@ -769,9 +771,8 @@ private:
 
         BitBoard pin;
         while (pt_attacks) {
-            const auto possible_pinned
-                = Attacks::between(king_sq, Square(pt_attacks.poplsb())) & occ_us;
-            if ((possible_pinned).count() == 1) pin |= possible_pinned;
+            const auto possible_pin = Attacks::between(king_sq, Square(pt_attacks.poplsb()));
+            if ((possible_pin & occ_us).count() == 1) pin |= possible_pin;
         }
         return pin;
     }

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -67,7 +67,7 @@ private:
     std::array<BitBoard, 6> pieces_ = {};          // [048] 48  bitboard per piece type
     std::array<BitBoard, 2> occ_ = {};             // [064] 16  bitboard per color
     std::array<Piece, 64> mailbox_ = {};           // [128] 64  piece on each square
-    BitBoard threats_ = {};                        // [136] 16  squares attacked by ntm
+    BitBoard threats_ = {};                        // [136] 16  attacked sqs by ntm (xrays stm king)
     std::array<BitBoard, 2> pinned_ = {};          // [152] 32  pinned pieces per color
     MultiArray<BitBoard, 2, 2> castle_path_ = {};  // [184] 32  castling path for color and side
     u64 hash_ = 0;                                 // [192] 8   zobrist hash
@@ -178,13 +178,15 @@ public:
         if (color == ~stm_) return threats_.is_set(sq);
 
         // cheap checks first
+        const auto xrayocc = occ() ^ BitBoard::from_square(king_square(stm_));
         if (Attacks::pawn(sq, ~color) & occ(PieceType::PAWN, color)) return true;
         if (Attacks::knight(sq) & occ(PieceType::KNIGHT, color)) return true;
         if (Attacks::king(sq) & occ(PieceType::KING, color)) return true;
-        if (Attacks::bishop(sq, occ()) & (occ(PieceType::BISHOP) | occ(PieceType::QUEEN))
+        if (Attacks::bishop(sq, xrayocc) & (occ(PieceType::BISHOP) | occ(PieceType::QUEEN))
             & occ(color))
             return true;
-        if (Attacks::rook(sq, occ()) & (occ(PieceType::ROOK) | occ(PieceType::QUEEN)) & occ(color))
+        if (Attacks::rook(sq, xrayocc) & (occ(PieceType::ROOK) | occ(PieceType::QUEEN))
+            & occ(color))
             return true;
 
         return false;
@@ -720,18 +722,19 @@ private:
     [[nodiscard]] BitBoard compute_threats() const {
         BitBoard threats;
 
+        const auto xrayocc = occ() ^ BitBoard::from_square(king_square(stm_));
         const auto queens = occ(PieceType::QUEEN, ~stm_);
 
         auto rooks = occ(PieceType::ROOK, ~stm_) | queens;
         while (rooks) {
             const auto sq = Square(rooks.poplsb());
-            threats |= Attacks::rook(sq, occ());
+            threats |= Attacks::rook(sq, xrayocc);
         }
 
         auto bishops = occ(PieceType::BISHOP, ~stm_) | queens;
         while (bishops) {
             const auto sq = Square(bishops.poplsb());
-            threats |= Attacks::bishop(sq, occ());
+            threats |= Attacks::bishop(sq, xrayocc);
         }
 
         auto knights = occ(PieceType::KNIGHT, ~stm_);

--- a/src/chess/movegen.h
+++ b/src/chess/movegen.h
@@ -48,6 +48,9 @@ template <Color::underlying color>
 [[nodiscard]] inline std::pair<BitBoard, i32> Movegen::check_mask(const Board& board, Square sq) {
     assert(board.stm() == color);
 
+    // short circuit if our king isn't attacked
+    if (!board.threats().is_set(sq)) return {BitBoard::FULL, 0};
+
     const auto opp_knight = board.occ(PieceType::KNIGHT, ~static_cast<Color>(color));
     const auto opp_bishop = board.occ(PieceType::BISHOP, ~static_cast<Color>(color));
     const auto opp_rook = board.occ(PieceType::ROOK, ~static_cast<Color>(color));
@@ -85,7 +88,7 @@ template <Color::underlying color>
         checks++;
     }
 
-    if (!mask) return {BitBoard::FULL, checks};
+    assert(!mask.is_empty());
     return {mask, checks};
 }
 
@@ -95,6 +98,9 @@ template <Color::underlying color, PieceType::underlying pt>
 ) {
     static_assert(pt == PieceType::BISHOP || pt == PieceType::ROOK);
     assert(board.stm() == color);
+
+    // short circuit if none of our pieces are pinned
+    if (board.pinned(static_cast<Color>(color)).is_empty()) return BitBoard(0);
 
     const auto opp_pt_queen = (board.occ(static_cast<PieceType>(pt)) | board.occ(PieceType::QUEEN))
                               & board.occ(~static_cast<Color>(color));
@@ -355,7 +361,7 @@ template <Color::underlying color>
 
 template <Color::underlying color>
 [[nodiscard]] inline BitBoard Movegen::generate_legal_castles(
-    const Board& board, Square sq, BitBoard seen, BitBoard pin_hv
+    const Board& board, Square sq, BitBoard seen
 ) {
     assert(board.stm() == color);
 
@@ -381,8 +387,7 @@ template <Color::underlying color>
         const auto rook_from = BitBoard::from_square(
             Square(rights.get_rook_file(static_cast<Color>(color), side), sq.rank())
         );
-        if (board.chess960() && (pin_hv & board.occ(static_cast<Color>(color)) & rook_from))
-            continue;
+        if (board.chess960() && (board.pinned(static_cast<Color>(color)) & rook_from)) continue;
 
         moves |= rook_from;
     }
@@ -435,7 +440,7 @@ inline void Movegen::generate_legals(MoveList<ScoredMove>& movelist, const Board
     });
 
     if (mt != MoveGenType::NOISY && checks == 0) {
-        BitBoard moves = generate_legal_castles<color>(board, king_sq, seen, pin_hv);
+        BitBoard moves = generate_legal_castles<color>(board, king_sq, seen);
         while (moves) {
             const auto to = static_cast<Square>(moves.poplsb());
             movelist.push({.move = Move::make<Move::CASTLING>(king_sq, to)});

--- a/src/chess/movegen.h
+++ b/src/chess/movegen.h
@@ -26,13 +26,12 @@ template <Color::underlying color>
 [[nodiscard]] inline bool Movegen::is_ep_valid(const Board& board, Square ep) {
     assert(board.stm() == color);
 
-    const auto occ_us = board.occ(static_cast<Color>(color));
-    const auto occ_opp = board.occ(~static_cast<Color>(color));
     const auto king_sq = board.king_square(static_cast<Color>(color));
 
     const auto [checkmask, _] = check_mask<color>(board, king_sq);
-    const auto pin_hv = pin_mask<color, PieceType::ROOK>(board, king_sq, occ_opp, occ_us);
-    const auto pin_d = pin_mask<color, PieceType::BISHOP>(board, king_sq, occ_opp, occ_us);
+    const auto pinmask = board.pinmask(static_cast<Color>(color));
+    const auto pin_hv = Attacks::rook(king_sq, BitBoard(0)) & pinmask;
+    const auto pin_d = Attacks::bishop(king_sq, BitBoard(0)) & pinmask;
 
     const auto pawns = board.occ(PieceType::PAWN, static_cast<Color>(color));
     const auto pawns_lr = pawns & ~pin_hv;
@@ -90,28 +89,6 @@ template <Color::underlying color>
 
     assert(!mask.is_empty());
     return {mask, checks};
-}
-
-template <Color::underlying color, PieceType::underlying pt>
-[[nodiscard]] inline BitBoard Movegen::pin_mask(
-    const Board& board, Square sq, BitBoard occ_opp, BitBoard occ_us
-) {
-    static_assert(pt == PieceType::BISHOP || pt == PieceType::ROOK);
-    assert(board.stm() == color);
-
-    // short circuit if none of our pieces are pinned
-    if (board.pinned(static_cast<Color>(color)).is_empty()) return BitBoard(0);
-
-    const auto opp_pt_queen = (board.occ(static_cast<PieceType>(pt)) | board.occ(PieceType::QUEEN))
-                              & board.occ(~static_cast<Color>(color));
-    auto pt_attacks = Attacks::slider<pt>(sq, occ_opp) & opp_pt_queen;
-
-    BitBoard pin = 0;
-    while (pt_attacks) {
-        const auto possible_pin = Attacks::between(sq, static_cast<Square>(pt_attacks.poplsb()));
-        if ((possible_pin & occ_us).count() == 1) pin |= possible_pin;
-    }
-    return pin;
 }
 
 
@@ -397,8 +374,9 @@ inline void Movegen::generate_legals(MoveList<ScoredMove>& movelist, const Board
     const auto occ_all = occ_us | occ_opp;
 
     const auto [checkmask, checks] = check_mask<color>(board, king_sq);
-    const auto pin_hv = pin_mask<color, PieceType::ROOK>(board, king_sq, occ_opp, occ_us);
-    const auto pin_d = pin_mask<color, PieceType::BISHOP>(board, king_sq, occ_opp, occ_us);
+    const auto pinmask = board.pinmask(static_cast<Color>(color));
+    const auto pin_hv = Attacks::rook(king_sq, BitBoard(0)) & pinmask;
+    const auto pin_d = Attacks::bishop(king_sq, BitBoard(0)) & pinmask;
     assert(checks <= 2);
 
     BitBoard movable_square;
@@ -494,8 +472,9 @@ template <Color::underlying color>
     const auto king_sq = board.king_square(static_cast<Color>(color));
 
     const auto [checkmask, checks] = check_mask<color>(board, king_sq);
-    const auto pin_hv = pin_mask<color, PieceType::ROOK>(board, king_sq, occ_opp, occ_us);
-    const auto pin_d = pin_mask<color, PieceType::BISHOP>(board, king_sq, occ_opp, occ_us);
+    const auto pinmask = board.pinmask(static_cast<Color>(color));
+    const auto pin_hv = Attacks::rook(king_sq, BitBoard(0)) & pinmask;
+    const auto pin_d = Attacks::bishop(king_sq, BitBoard(0)) & pinmask;
     assert(checks <= 2);
 
     // only king moves allowed in double check

--- a/src/chess/movegen.h
+++ b/src/chess/movegen.h
@@ -114,29 +114,6 @@ template <Color::underlying color, PieceType::underlying pt>
     return pin;
 }
 
-template <Color::underlying color>
-[[nodiscard]] inline BitBoard Movegen::seen_squares(const Board& board, BitBoard opp_empty) {
-    const auto king_sq = board.king_square(~static_cast<Color>(color));
-    BitBoard map_king_atk = Attacks::king(king_sq) & opp_empty;
-    if (map_king_atk.is_empty() && !board.chess960()) return 0;
-
-    const auto occ = board.occ() ^ BitBoard::from_square(king_sq);
-    const auto queens = board.occ(PieceType::QUEEN, static_cast<Color>(color));
-    const auto pawns = board.occ(PieceType::PAWN, static_cast<Color>(color));
-    auto knights = board.occ(PieceType::KNIGHT, static_cast<Color>(color));
-    auto bishops = board.occ(PieceType::BISHOP, static_cast<Color>(color)) | queens;
-    auto rooks = board.occ(PieceType::ROOK, static_cast<Color>(color)) | queens;
-
-    auto seen = Attacks::pawn_left<color>(pawns) | Attacks::pawn_right<color>(pawns);
-
-    while (knights) seen |= Attacks::knight(static_cast<Square>(knights.poplsb()));
-    while (bishops) seen |= Attacks::bishop(static_cast<Square>(bishops.poplsb()), occ);
-    while (rooks) seen |= Attacks::rook(static_cast<Square>(rooks.poplsb()), occ);
-    seen |= Attacks::king(board.king_square(static_cast<Color>(color)));
-
-    return seen;
-}
-
 
 template <Color::underlying color, Movegen::MoveGenType mt>
 inline void Movegen::generate_legal_pawns(
@@ -418,7 +395,6 @@ inline void Movegen::generate_legals(MoveList<ScoredMove>& movelist, const Board
     const auto occ_us = board.occ(static_cast<Color>(color));
     const auto occ_opp = board.occ(~static_cast<Color>(color));
     const auto occ_all = occ_us | occ_opp;
-    const auto opp_empty = ~occ_us;
 
     const auto [checkmask, checks] = check_mask<color>(board, king_sq);
     const auto pin_hv = pin_mask<color, PieceType::ROOK>(board, king_sq, occ_opp, occ_us);
@@ -427,14 +403,14 @@ inline void Movegen::generate_legals(MoveList<ScoredMove>& movelist, const Board
 
     BitBoard movable_square;
     if constexpr (mt == MoveGenType::ALL)
-        movable_square = opp_empty;
+        movable_square = ~occ_us;
     else if constexpr (mt == MoveGenType::NOISY)
         movable_square = occ_opp;
     else
         movable_square = ~occ_all;
 
     // generate king moves
-    const auto seen = seen_squares<~color>(board, opp_empty);
+    const auto seen = board.threats();
     push_moves(movelist, BitBoard::from_square(king_sq), [&](Square sq) {
         return generate_legal_kings(sq, seen, movable_square);
     });
@@ -506,11 +482,10 @@ template <Color::underlying color>
     const auto occ_us = board.occ(static_cast<Color>(color));
     const auto occ_opp = board.occ(~static_cast<Color>(color));
     const auto occ_all = occ_us | occ_opp;
-    const auto opp_empty = ~occ_us;
 
     // non-castling king moves (check for normal as king could be in place of a previous promo/ep)
     if (from_pt.type() == PieceType::KING && move.type() == Move::NORMAL) {
-        const auto seen = seen_squares<~color>(board, opp_empty);
+        const auto seen = board.threats();
         if (seen.is_set(to)) return false;
         if (!(Attacks::king(from).is_set(to))) return false;
         return true;
@@ -554,7 +529,7 @@ template <Color::underlying color>
 
         // king path should not be attacked
         const auto king_to = Square::castling_king_dest(is_king_side, static_cast<Color>(color));
-        const auto seen = seen_squares<~color>(board, opp_empty);
+        const auto seen = board.threats();
         if (Attacks::between(from, king_to) & seen) return false;
 
         // rook on backrank should not be pinned in chess960

--- a/src/chess/movegen_fwd.h
+++ b/src/chess/movegen_fwd.h
@@ -91,7 +91,7 @@ private:
 
     template <Color::underlying color>
     [[nodiscard]] static BitBoard generate_legal_castles(
-        const Board& board, Square sq, BitBoard seen, BitBoard pin_hv
+        const Board& board, Square sq, BitBoard seen
     );
 
 

--- a/src/chess/movegen_fwd.h
+++ b/src/chess/movegen_fwd.h
@@ -47,11 +47,6 @@ private:
     template <Color::underlying color>
     [[nodiscard]] static std::pair<BitBoard, i32> check_mask(const Board& board, Square sq);
 
-    template <Color::underlying color, PieceType::underlying pt>
-    [[nodiscard]] static BitBoard pin_mask(
-        const Board& board, Square sq, BitBoard occ_opp, BitBoard occ_us
-    );
-
 
     template <Color::underlying color, MoveGenType mt>
     static void generate_legal_pawns(

--- a/src/chess/movegen_fwd.h
+++ b/src/chess/movegen_fwd.h
@@ -52,9 +52,6 @@ private:
         const Board& board, Square sq, BitBoard occ_opp, BitBoard occ_us
     );
 
-    template <Color::underlying color>
-    [[nodiscard]] static BitBoard seen_squares(const Board& board, BitBoard opp_empty);
-
 
     template <Color::underlying color, MoveGenType mt>
     static void generate_legal_pawns(


### PR DESCRIPTION
```
Elo   | 2.95 +- 3.83 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 8610 W: 2092 L: 2019 D: 4499
Penta | [47, 930, 2295, 969, 64]
```
https://rmeguro.pythonanywhere.com/test/214/
bench: 8683935