### PR TITLE
feat: nonpawn correction history

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The engine contains the following features:
     - [x] SEE                               (`v1.7+`)
     - [x] Pawn correction history           (`v3.3+`)
     - [x] Major piece correction history    (`v3.3+`)
-    - [ ] Nonpawn correction history
+    - [x] Nonpawn correction history        (`v3.3+`)
     - [ ] Continuation correction history
 - [x] Quiescence search                     (`v1.0+`)
   - ~~Delta pruning~~                       (`v2.1+`)

--- a/src/Raphael/History.cpp
+++ b/src/Raphael/History.cpp
@@ -37,7 +37,12 @@ void CorrectionEntry::update(i32 bonus) {
 
 
 History::History()
-    : butterfly_hist_{}, cont_hist_{}, capt_hist_{}, pawn_correction_{}, major_correction_{} {}
+    : butterfly_hist_{},
+      cont_hist_{},
+      capt_hist_{},
+      pawn_correction_{},
+      major_correction_{},
+      nonpawn_correction_{} {}
 
 
 i32 History::quiet_bonus(i32 depth) const {
@@ -128,12 +133,16 @@ void History::update_corrections(const chess::Board& board, i32 depth, i32 score
     );
     pawn_corr_entry(board).update(bonus);
     major_corr_entry(board).update(bonus);
+    nonpawn_corr_entry(board, chess::Color::WHITE).update(bonus);
+    nonpawn_corr_entry(board, chess::Color::BLACK).update(bonus);
 }
 
 i32 History::correct(const chess::Board& board, i32 score) const {
     i32 correction = 0;
     correction += pawn_corr_entry(board) * PAWN_CORRHIST_WEIGHT;
     correction += major_corr_entry(board) * MAJOR_CORRHIST_WEIGHT;
+    correction += nonpawn_corr_entry(board, chess::Color::WHITE) * NONPAWN_CORRHIST_WEIGHT;
+    correction += nonpawn_corr_entry(board, chess::Color::BLACK) * NONPAWN_CORRHIST_WEIGHT;
     correction /= CORRHIST_MAX;
 
     return clamp(score + correction, -MATE_SCORE + 1, MATE_SCORE - 1);
@@ -146,6 +155,7 @@ void History::clear() {
     memset(capt_hist_, 0, sizeof(capt_hist_));
     memset(pawn_correction_, 0, sizeof(pawn_correction_));
     memset(major_correction_, 0, sizeof(major_correction_));
+    memset(nonpawn_correction_, 0, sizeof(nonpawn_correction_));
 }
 
 
@@ -197,4 +207,13 @@ const CorrectionEntry& History::major_corr_entry(const chess::Board& board) cons
 }
 CorrectionEntry& History::major_corr_entry(const chess::Board& board) {
     return major_correction_[board.stm()][board.major_hash() % CORRHIST_SIZE];
+}
+
+const CorrectionEntry& History::nonpawn_corr_entry(
+    const chess::Board& board, chess::Color color
+) const {
+    return nonpawn_correction_[board.stm()][color][board.nonpawn_hash(color) % CORRHIST_SIZE];
+}
+CorrectionEntry& History::nonpawn_corr_entry(const chess::Board& board, chess::Color color) {
+    return nonpawn_correction_[board.stm()][color][board.nonpawn_hash(color) % CORRHIST_SIZE];
 }

--- a/src/Raphael/History.h
+++ b/src/Raphael/History.h
@@ -44,8 +44,9 @@ private:
     HistoryEntry cont_hist_[12][64][12][64];     // [prev from][prev to][from][to]
     HistoryEntry capt_hist_[64][64][13];         // [from][to][piece, 12 for non-capture queening]
 
-    CorrectionEntry pawn_correction_[2][CORRHIST_SIZE];   // [stm][pawn_hash % CORRHIST_SIZE]
-    CorrectionEntry major_correction_[2][CORRHIST_SIZE];  // [stm][major_hash % CORRHIST_SIZE]
+    CorrectionEntry pawn_correction_[2][CORRHIST_SIZE];        // [stm][pawn_hash idx]
+    CorrectionEntry major_correction_[2][CORRHIST_SIZE];       // [stm][major_hash idx]
+    CorrectionEntry nonpawn_correction_[2][2][CORRHIST_SIZE];  // [stm][color][nonpawn_hash idx]
 
 public:
     /** Initializes all the history tables with zeros */
@@ -190,5 +191,14 @@ private:
      */
     const CorrectionEntry& major_corr_entry(const chess::Board& board) const;
     CorrectionEntry& major_corr_entry(const chess::Board& board);
+
+    /** Returns a reference to the non-pawn corrhist entry
+     *
+     * \param board current board
+     * \param color color of non-pawns
+     * \returns non-pawn corrhist entry
+     */
+    const CorrectionEntry& nonpawn_corr_entry(const chess::Board& board, chess::Color color) const;
+    CorrectionEntry& nonpawn_corr_entry(const chess::Board& board, chess::Color color);
 };
 }  // namespace raphael

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -299,6 +299,7 @@ static constexpr i32 CORRHIST_BONUS_MAX = 256;
 
 Tunable(PAWN_CORRHIST_WEIGHT, 64, 32, 384, true);
 Tunable(MAJOR_CORRHIST_WEIGHT, 64, 32, 384, true);
+Tunable(NONPAWN_CORRHIST_WEIGHT, 64, 32, 384, true);
 
 // commands
 static constexpr i32 BENCH_DEPTH = 14;

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -516,6 +516,10 @@ public:
             }
         }
 
+        threats_ = compute_threats();
+        pinmask_[Color::WHITE] = compute_pinmask(Color::WHITE);
+        pinmask_[Color::BLACK] = compute_pinmask(Color::BLACK);
+
         // validate enpassant
         if (enpassant_ != Square::NONE) {
             bool valid;
@@ -548,9 +552,6 @@ public:
         }
 
         recompute_hash();
-        threats_ = compute_threats();
-        pinmask_[Color::WHITE] = compute_pinmask(Color::WHITE);
-        pinmask_[Color::BLACK] = compute_pinmask(Color::BLACK);
     }
 
     [[nodiscard]] std::string get_fen() const {

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -73,12 +73,13 @@ private:
     u64 hash_ = 0;                                 // [192] 8   zobrist hash
     u64 pawn_hash_ = 0;                            // [200] 8   zobrist hash of pawns
     u64 major_hash_ = 0;                           // [208] 8   zobrist hash of major pieces
-    CastlingRights castle_rights_ = {};            // [216] 2   allowed castling files
-    u16 plies_ = 1;                                // [216] 2   number of plies
-    u8 halfmoves_ = 0;                             // [216] 1   plies since last capture/pawn move
-    Color stm_ = Color::WHITE;                     // [216] 1   current stm
-    Square enpassant_ = Square::NONE;              // [216] 1   enpassant square
-    bool chess960_ = false;                        // [216] 1   whether chess960 is enabled
+    u64 nonpawn_hash_[2] = {};                     // [224] 16  zobrist hash of non-pawns per color
+    CastlingRights castle_rights_ = {};            // [232] 2   allowed castling files
+    u16 plies_ = 1;                                // [232] 2   number of plies
+    u8 halfmoves_ = 0;                             // [232] 1   plies since last capture/pawn move
+    Color stm_ = Color::WHITE;                     // [232] 1   current stm
+    Square enpassant_ = Square::NONE;              // [232] 1   enpassant square
+    bool chess960_ = false;                        // [232] 1   whether chess960 is enabled
 
 
 public:
@@ -109,6 +110,7 @@ public:
     [[nodiscard]] u64 hash() const { return hash_; }
     [[nodiscard]] u64 pawn_hash() const { return pawn_hash_; }
     [[nodiscard]] u64 major_hash() const { return major_hash_; }
+    [[nodiscard]] u64 nonpawn_hash(Color color) const { return nonpawn_hash_[color]; }
 
     [[nodiscard]] bool chess960() const { return chess960_; }
 
@@ -639,6 +641,8 @@ private:
         hash_ = 0;
         pawn_hash_ = 0;
         major_hash_ = 0;
+        nonpawn_hash_[Color::WHITE] = 0;
+        nonpawn_hash_[Color::BLACK] = 0;
     }
 
 
@@ -680,8 +684,10 @@ private:
         hash_ ^= key;
         if (piece.type() == PieceType::PAWN)
             pawn_hash_ ^= key;
-        else if (piece.type() == PieceType::ROOK || piece.type() == PieceType::QUEEN)
-            major_hash_ ^= key;
+        else
+            nonpawn_hash_[piece.color()] ^= key;
+
+        if (piece.type() == PieceType::ROOK || piece.type() == PieceType::QUEEN) major_hash_ ^= key;
     }
 
     void update_ep_hash(File file) {
@@ -706,6 +712,8 @@ private:
         hash_ = 0;
         pawn_hash_ = 0;
         major_hash_ = 0;
+        nonpawn_hash_[Color::WHITE] = 0;
+        nonpawn_hash_[Color::BLACK] = 0;
 
         auto pieces = occ();
         while (pieces) {
@@ -805,5 +813,5 @@ private:
     }
 };
 
-static_assert(sizeof(Board) == 216);
+static_assert(sizeof(Board) == 232);
 }  // namespace chess

--- a/src/tests/hash.cpp
+++ b/src/tests/hash.cpp
@@ -13,6 +13,8 @@ TEST_SUITE("Zobrist Hash") {
         CHECK(b.hash() == 0x463b96181691fc9c);
         CHECK(b.pawn_hash() == 0x37FC40DA841E1692);
         CHECK(b.major_hash() == 0x35DB1B902419D42F);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x99A544452583308C);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         auto mv = Move::make(Square::E2, Square::E4);
         CHECK(b.hash_after<true>(mv) == 0x823c9b50fd114196);
@@ -21,6 +23,8 @@ TEST_SUITE("Zobrist Hash") {
         CHECK(b.hash() == 0x823c9b50fd114196);
         CHECK(b.pawn_hash() == 0xB2D6B38C0B92E91);
         CHECK(b.major_hash() == 0x35DB1B902419D42F);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x99A544452583308C);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         mv = Move::make(Square::D7, Square::D5);
         CHECK(b.hash_after<true>(mv) == 0x0756b94461c50fb0);
@@ -29,6 +33,8 @@ TEST_SUITE("Zobrist Hash") {
         CHECK(b.hash() == 0x0756b94461c50fb0);
         CHECK(b.pawn_hash() == 0x76916F86F34AE5BE);
         CHECK(b.major_hash() == 0x35DB1B902419D42F);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x99A544452583308C);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         mv = Move::make(Square::E4, Square::E5);
         CHECK(b.hash_after<true>(mv) == 0x662fafb965db29d4);
@@ -37,6 +43,8 @@ TEST_SUITE("Zobrist Hash") {
         CHECK(b.hash() == 0x662fafb965db29d4);
         CHECK(b.pawn_hash() == 0xEF3E5FD1587346D3);
         CHECK(b.major_hash() == 0x35DB1B902419D42F);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x99A544452583308C);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         mv = Move::make(Square::F7, Square::F5);
         CHECK(b.hash_after<true>(mv) == 0x22a48b5a8e47ff78);
@@ -44,6 +52,8 @@ TEST_SUITE("Zobrist Hash") {
         CHECK(b.hash() == 0x22a48b5a8e47ff78);
         CHECK(b.pawn_hash() == 0x53635D981CC81576);
         CHECK(b.major_hash() == 0x35DB1B902419D42F);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x99A544452583308C);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         mv = Move::make(Square::E1, Square::E2);
         CHECK(b.hash_after<true>(mv) == 0x652a607ca3f242c1);
@@ -51,6 +61,8 @@ TEST_SUITE("Zobrist Hash") {
         CHECK(b.hash() == 0x652a607ca3f242c1);
         CHECK(b.pawn_hash() == 0x83871FE249DCEE04);
         CHECK(b.major_hash() == 0xF569B3D99F2296AF);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x36AB63FA493EB1CE);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         mv = Move::make(Square::E8, Square::F7);
         CHECK(b.hash_after<true>(mv) == 0x00fdd303c946bdd9);
@@ -58,6 +70,8 @@ TEST_SUITE("Zobrist Hash") {
         CHECK(b.hash() == 0x00fdd303c946bdd9);
         CHECK(b.pawn_hash() == 0x83871FE249DCEE04);
         CHECK(b.major_hash() == 0x4EE1363BF3987BC6);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x36AB63FA493EB1CE);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x4D0789B16683671A);
     }
 
     TEST_CASE("Test Zobrist Hash Second Position") {
@@ -69,6 +83,8 @@ TEST_SUITE("Zobrist Hash") {
         b.make_move(mv);
         CHECK(b.pawn_hash() == 0xA4E3189C46AA4655);
         CHECK(b.major_hash() == 0x35DB1B902419D42F);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x99A544452583308C);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         mv = Move::make(Square::B7, Square::B5);
         CHECK(b.hash_after<true>(mv) == 0x4DF682E1E0AF946F);
@@ -76,6 +92,8 @@ TEST_SUITE("Zobrist Hash") {
         b.make_move(mv);
         CHECK(b.pawn_hash() == 0x3C31542372207E61);
         CHECK(b.major_hash() == 0x35DB1B902419D42F);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x99A544452583308C);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         mv = Move::make(Square::H2, Square::H4);
         CHECK(b.hash_after<true>(mv) == 0xD1551EC84B90ED11);
@@ -83,6 +101,8 @@ TEST_SUITE("Zobrist Hash") {
         b.make_move(mv);
         CHECK(b.pawn_hash() == 0x5844EEA076388216);
         CHECK(b.major_hash() == 0x35DB1B902419D42F);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x99A544452583308C);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         mv = Move::make(Square::B5, Square::B4);
         CHECK(b.hash_after<true>(mv) == 0xB0982F168A89B452);
@@ -90,12 +110,16 @@ TEST_SUITE("Zobrist Hash") {
         b.make_move(mv);
         CHECK(b.pawn_hash() == 0xC15FF9D418065E5C);
         CHECK(b.major_hash() == 0x35DB1B902419D42F);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x99A544452583308C);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         mv = Move::make(Square::C2, Square::C4);
         CHECK(b.hash_after<true>(mv) == 0x3C8123EA7B067637);
         b.make_move(mv);
         CHECK(b.pawn_hash() == 0xB590D38246AE1930);
         CHECK(b.major_hash() == 0x35DB1B902419D42F);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x99A544452583308C);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         CHECK(b.hash() == 0x3c8123ea7b067637);
 
@@ -104,12 +128,16 @@ TEST_SUITE("Zobrist Hash") {
         b.make_move(mv);
         CHECK(b.pawn_hash() == 0xE214F040EAA135A0);
         CHECK(b.major_hash() == 0x35DB1B902419D42F);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x99A544452583308C);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         mv = Move::make(Square::A1, Square::A3);
         CHECK(b.hash_after<true>(mv) == 0x5c3f9b829b279560);
         b.make_move(mv);
         CHECK(b.pawn_hash() == 0xE214F040EAA135A0);
         CHECK(b.major_hash() == 0x2E1803A68371BE8);
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x5FFA6A68B6247EDB);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x6B8E9986CFAAF062);
 
         CHECK(b.hash() == 0x5c3f9b829b279560);
     }
@@ -347,5 +375,33 @@ TEST_SUITE("Zobrist Hash") {
 
         b.make_move(Move::make(Square::E8, Square::E7));
         CHECK(b.major_hash() == 0xD7333DA186CEA120);
+    }
+
+    TEST_CASE("Test Zobrist Nonpawn Pawn") {
+        Board b;
+
+        b.set_fen("r3kbnr/ppp1p1pp/8/8/8/8/PPPP1PPP/2N1K2R w Kkq - 0 3");
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0x9AEA3DFDD65D0B88);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0xB146EEEF9EB5E006);
+
+        b.make_move(Move::make<Move::CASTLING>(Square::E1, Square::H1));
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0xDCFBC82ABEB21711);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0xB146EEEF9EB5E006);
+
+        b.make_move(Move::make<Move::CASTLING>(Square::E8, Square::A8));
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0xDCFBC82ABEB21711);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0xC12ED8F9123EDC5C);
+
+        b.make_move(Move::make(Square::D2, Square::D4));
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0xDCFBC82ABEB21711);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0xC12ED8F9123EDC5C);
+
+        b.make_move(Move::make(Square::D8, Square::D4));
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0xDCFBC82ABEB21711);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x1FD0EE7063B4A5FC);
+
+        b.make_move(Move::make(Square::C1, Square::D3));
+        CHECK(b.nonpawn_hash(Color::WHITE) == 0xD1C7F409513FF167);
+        CHECK(b.nonpawn_hash(Color::BLACK) == 0x1FD0EE7063B4A5FC);
     }
 }


### PR DESCRIPTION
```
Elo   | 6.59 +- 4.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7066 W: 1741 L: 1607 D: 3718
Penta | [24, 815, 1737, 917, 40]
```
https://rmeguro.pythonanywhere.com/test/215/
bench: 8302097