### PR TITLE
feat: faster (but apparently lower quality) datagen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,6 +235,7 @@ bullet
 src/Games/stockfish/
 src/Games/*.pgn
 src/Games/*.epd
+*.vf
 
 # UCI
 *.uci_options

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -77,8 +77,10 @@ void Raphael::set_option(const std::string& name, i32 value) {
         // set value
         p->set(value);
 
-        lock_guard<mutex> lock(cout_mutex);
-        cout << "info string set " << p->name << " to " << value << "\n" << flush;
+        if (ucilevel_ != UciInfoLevel::NONE) {
+            lock_guard<mutex> lock(cout_mutex);
+            cout << "info string set " << p->name << " to " << value << "\n" << flush;
+        }
         return;
     }
 
@@ -92,11 +94,13 @@ void Raphael::set_option(const std::string& name, bool value) {
         // set value
         p->set(value);
 
-        lock_guard<mutex> lock(cout_mutex);
-        if (value)
-            cout << "info string enabled " << p->name << "\n" << flush;
-        else
-            cout << "info string disabled " << p->name << "\n" << flush;
+        if (ucilevel_ != UciInfoLevel::NONE) {
+            lock_guard<mutex> lock(cout_mutex);
+            if (value)
+                cout << "info string enabled " << p->name << "\n" << flush;
+            else
+                cout << "info string disabled " << p->name << "\n" << flush;
+        }
         return;
     }
 

--- a/src/Raphael/commands.cpp
+++ b/src/Raphael/commands.cpp
@@ -121,7 +121,6 @@ void genfens(
 ) {
     // based on https://github.com/official-clockwork/Clockwork/blob/main/src/uci.cpp
     engine.set_uciinfolevel(raphael::Raphael::UciInfoLevel::NONE);
-    engine.set_searchoptions({.maxnodes = GENFENS_MAX_NODES});
     engine.set_option("Softnodes", true);
 
     mt19937_64 generator(seed);
@@ -173,6 +172,8 @@ void genfens(
 
         // filter unbalanced/illegal positions
         atomic<bool> halt{false};
+        engine.reset();
+        engine.set_searchoptions({.maxnodes = GENFENS_MAX_NODES});
         engine.set_board(board);
         const auto res = engine.get_move(0, 0, halt);
         if (res.move == chess::Move::NO_MOVE || res.is_mate || abs(res.score) > GENFENS_MAX_SCORE)

--- a/src/Raphael/datagen.cpp
+++ b/src/Raphael/datagen.cpp
@@ -1,0 +1,351 @@
+#include <GameEngine/consts.h>
+#include <Raphael/datagen.h>
+
+#include <csignal>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <thread>
+
+using std::abs;
+using std::atomic;
+using std::cout;
+using std::flush;
+using std::ifstream;
+using std::lock_guard;
+using std::memory_order_relaxed;
+using std::mt19937_64;
+using std::mutex;
+using std::ofstream;
+using std::signal;
+using std::string;
+using std::thread;
+using std::to_string;
+using std::uniform_int_distribution;
+using std::vector;
+namespace ch = std::chrono;
+
+
+
+namespace raphael::datagen {
+namespace internal {
+PackedBoard PackedBoard::pack(const chess::Board& board, i16 score) {
+    // https://github.com/jnlt3/marlinflow/blob/main/marlinformat/src/lib.rs
+    // https://github.com/Ciekce/Stormphrax/blob/main/src/datagen/marlinformat.h
+    PackedBoard packed{};
+
+    const auto cr = board.castle_rights();
+    constexpr auto kside = chess::Board::CastlingRights::KING_SIDE;
+    constexpr auto qside = chess::Board::CastlingRights::QUEEN_SIDE;
+    constexpr u8 unmoved_rook_id = 6;
+
+    auto occ = board.occ();
+    packed.occ = static_cast<u64>(occ);
+
+    i32 i = 0;
+    while (occ) {
+        const auto sq = static_cast<chess::Square>(occ.poplsb());
+        const auto p = board.at(sq);
+
+        u8 pt_id = static_cast<u8>(p.type());
+        const u8 col_id = static_cast<u8>((p.color() == chess::Color::WHITE) ? 0 : (1 << 3));
+
+        if (p.type() == chess::PieceType::ROOK
+            && (sq.file() == cr.get_rook_file(chess::Color::WHITE, kside)
+                || sq.file() == cr.get_rook_square(chess::Color::WHITE, qside)
+                || sq.file() == cr.get_rook_square(chess::Color::BLACK, kside)
+                || sq.file() == cr.get_rook_square(chess::Color::BLACK, qside)))
+            pt_id = unmoved_rook_id;
+
+        const u8 encoding = pt_id | col_id;
+        assert(encoding <= 0xF);
+        assert(i < 32);
+        packed.pieces[i / 2] |= (i % 2 == 0) ? encoding : encoding << 4;
+        i++;
+    }
+
+    const u8 stm_id = (board.stm() == chess::Color::WHITE) ? 0 : (1 << 7);
+    const auto enpassant = board.enpassant_square();
+    const auto rel_enpassant = (enpassant == chess::Square::NONE) ? chess::Square::NONE
+                                                                  : enpassant.relative(board.stm());
+    packed.stm_enpassant = stm_id | static_cast<u8>(rel_enpassant);
+    packed.halfmoves = board.halfmoves();
+    packed.fullmoves = board.fullmoves();
+    packed.eval = score;
+
+    return packed;
+}
+
+ViriMove ViriMove::from_move(chess::Move move, i32 score) {
+    ViriMove virimove;
+
+    static constexpr u16 virimovetypes[4] = {
+        static_cast<u16>(0x0000),  // normal
+        static_cast<u16>(0xC000),  // promo
+        static_cast<u16>(0x4000),  // enpassant
+        static_cast<u16>(0x8000),  // castling
+    };
+
+    // the move type is encoded slightly differently, so we replace it
+    virimove.move |= static_cast<u16>(move);
+    virimove.move &= 0x3FFF;
+    virimove.move |= virimovetypes[move.type() >> 14];
+
+    assert(score <= INT16_MAX);
+    assert(score >= INT16_MIN);
+    virimove.score = score;
+
+    return virimove;
+}
+
+
+void generation_thread(
+    Raphael* engine,
+    i32 softnodes,
+    vector<string> seed_fens,
+    string filename,
+    u64 seed,
+    i32 randmoves,
+    bool dfrc
+) {
+    // create engine if not passed
+    bool created_engine = false;
+    if (engine == nullptr) {
+        engine = new Raphael("Raphael");
+        created_engine = true;
+    }
+
+    // initialize engine
+    engine->set_uciinfolevel(raphael::Raphael::UciInfoLevel::NONE);
+    engine->set_option("Softnodes", true);
+    engine->set_option("Hash", DATAGEN_HASH);
+    engine->set_option("Threads", 1);
+
+    // initialize other stuff
+    ofstream outfile(filename);
+    mt19937_64 generator(seed);
+    chess::Board board;
+    board.set960(dfrc);
+    chess::MoveList<chess::ScoredMove> movelist;
+    Position<false> position;
+    atomic<bool> halt{false};
+
+
+    // keep generating upon wakeup
+    while (true) {
+        {
+            lock_guard<mutex> gen_lock(gen_mutex);
+            if (num_batch_remaining == 0) break;
+            num_batch_remaining--;
+        }
+
+        // generate DATAGEN_BATCH_SIZE games
+        i32 generated = 0;
+        while (generated < DATAGEN_BATCH_SIZE) {
+            // choose random seed_fen
+            uniform_int_distribution<u64> distribution(0, seed_fens.size() - 1);
+            board.set_fen(seed_fens[distribution(generator)]);
+
+            // play random moves
+            for (i32 m = 0; m < randmoves; m++) {
+                movelist.clear();
+                chess::Movegen::generate_legals(movelist, board);
+                if (movelist.size() == 0) break;
+
+                uniform_int_distribution<u64> distribution(0, movelist.size() - 1);
+                const auto& move = movelist[distribution(generator)].move;
+                board.make_move(move);
+            }
+
+            // filter unbalanced/illegal positions
+            halt.store(false, memory_order_relaxed);
+            engine->reset();
+            engine->set_searchoptions({.maxnodes = GENFENS_MAX_NODES});
+            engine->set_board(board);
+            const auto res = engine->get_move(0, 0, halt);
+            if (res.move == chess::Move::NO_MOVE || res.is_mate
+                || abs(res.score) > GENFENS_MAX_SCORE)
+                continue;
+
+            // play from here
+            engine->set_searchoptions({.maxnodes = softnodes});
+            position.set_board(board);
+
+            auto packed = PackedBoard::pack(board, 0);
+            vector<ViriMove> movescores;
+            movescores.reserve(256);
+            Outcome outcome = Outcome::INVALID;
+            i32 winning_for = 0;
+            i32 losing_for = 0;
+            i32 drawing_for = 0;
+
+            while (outcome == Outcome::INVALID) {
+                const auto& curr_board = position.board();
+                const auto stm = curr_board.stm();
+
+                halt.store(false, memory_order_relaxed);
+                engine->set_position(position);
+                const auto res = engine->get_move(0, 0, halt);
+                auto abs_score = (stm == chess::Color::WHITE) ? res.score : -res.score;
+
+                // handle terminal state
+                if (res.move == chess::Move::NO_MOVE) {
+                    if (curr_board.in_check())
+                        outcome = (stm == chess::Color::WHITE) ? Outcome::BLACK_WIN
+                                                               : Outcome::WHITE_WIN;
+                    else
+                        outcome = Outcome::DRAW;
+                    break;
+                }
+
+                // reset draw adj counter on capture/pawn push
+                if (curr_board.is_capture(res.move)
+                    || curr_board.at(res.move.from()).type() == chess::PieceType::PAWN)
+                    drawing_for = 0;
+
+                // track adjudication
+                if (res.is_mate) {
+                    outcome = (abs_score > 0) ? Outcome::WHITE_WIN : Outcome::BLACK_WIN;
+                    abs_score = (abs_score > 0) ? MATE_SCORE : -MATE_SCORE;
+                } else {
+                    if (abs_score > DATAGEN_WIN_ADJ_SCORE) {
+                        winning_for++;
+                        losing_for = 0;
+                        drawing_for = 0;
+                    } else if (abs_score < -DATAGEN_WIN_ADJ_SCORE) {
+                        winning_for = 0;
+                        losing_for++;
+                        drawing_for = 0;
+                    } else if (curr_board.fullmoves() > DATAGEN_DRAW_ADJ_MVNUM
+                               && abs(abs_score) < DATAGEN_DRAW_ADJ_SCORE) {
+                        winning_for = 0;
+                        losing_for = 0;
+                        drawing_for++;
+                    } else {
+                        winning_for = 0;
+                        losing_for = 0;
+                        drawing_for = 0;
+                    }
+
+                    if (winning_for >= DATAGEN_WIN_ADJ_MVCNT)
+                        outcome = Outcome::WHITE_WIN;
+                    else if (losing_for >= DATAGEN_WIN_ADJ_MVCNT)
+                        outcome = Outcome::BLACK_WIN;
+                    else if (drawing_for >= DATAGEN_DRAW_ADJ_MVCNT)
+                        outcome = Outcome::DRAW;
+                }
+
+                position.make_move(res.move);
+
+                // handle draws
+                if (curr_board.is_halfmovedraw() || curr_board.is_insufficientmaterial()
+                    || position.is_repetition())
+                    outcome = Outcome::DRAW;
+
+                movescores.push_back(ViriMove::from_move(res.move, abs_score));
+            }
+
+            // write to outfile
+            static constexpr i32 null = 0;
+            packed.outcome = outcome;
+            outfile.write(reinterpret_cast<const char*>(&packed), sizeof(packed));
+            outfile.write(
+                reinterpret_cast<const char*>(movescores.data()),
+                sizeof(ViriMove) * movescores.size()
+            );
+            outfile.write(reinterpret_cast<const char*>(&null), sizeof(ViriMove));
+            generated++;
+        }
+
+        {
+            lock_guard<mutex> lock(cout_mutex);
+            num_games_generated += generated;
+            cout << "\rgenerated: " + to_string(num_games_generated) + " games" << flush;
+        }
+    }
+
+    outfile.close();
+    if (created_engine) delete engine;
+}
+
+
+void handle_interrupt(i32) {
+    lock_guard<mutex> gen_lock(gen_mutex);
+    num_batch_remaining = 0;
+}
+}  // namespace internal
+
+
+
+void generate_games(
+    Raphael& main_engine,
+    i32 softnodes,
+    i32 games,
+    const string& book,
+    i32 randmoves,
+    bool dfrc,
+    i32 concurrency
+) {
+    signal(SIGINT, internal::handle_interrupt);
+
+    // load seed_fens from book
+    vector<string> seed_fens;
+    if (book == "None")
+        seed_fens.push_back(chess::Board::STARTPOS);
+    else {
+        ifstream file(book);
+        if (!file) {
+            lock_guard<mutex> lock(cout_mutex);
+            cout << "info string could not open book: " << book << "\n" << flush;
+            return;
+        }
+
+        string seed_fen;
+        while (getline(file, seed_fen))
+            if (!seed_fen.empty()) seed_fens.push_back(seed_fen);
+
+        if (seed_fens.empty()) {
+            lock_guard<mutex> lock(cout_mutex);
+            cout << "info string book file is empty\n" << flush;
+            return;
+        }
+        file.close();
+    }
+
+    // get current time to use as seed
+    const auto current_time = ch::system_clock::now().time_since_epoch();
+    const auto base_seed
+        = static_cast<u64>(ch::duration_cast<ch::milliseconds>(current_time).count());
+    mt19937_64 generator(base_seed);
+    uniform_int_distribution<u64> distribution(0, UINT64_MAX);
+
+    // set total number of batches to run
+    internal::num_batch_remaining = (games + DATAGEN_BATCH_SIZE - 1) / DATAGEN_BATCH_SIZE;
+    {
+        lock_guard<mutex> lock(cout_mutex);
+        cout << "starting generation of " + to_string(games) + " games\n"
+             << "generated: 0 games" << flush;
+    }
+
+    // start generation threads
+    thread threads[concurrency];
+    for (int i = 0; i < concurrency; i++)
+        threads[i] = thread(
+            internal::generation_thread,
+            (i == 0) ? &main_engine : nullptr,
+            softnodes,
+            seed_fens,
+            to_string(base_seed) + "-" + to_string(i) + ".vf",
+            distribution(generator),
+            randmoves,
+            dfrc
+        );
+
+    // wait for completion
+    for (int i = 0; i < concurrency; i++) threads[i].join();
+
+    lock_guard<mutex> lock(cout_mutex);
+    cout << "\nfinished generation of " + to_string(internal::num_games_generated) + " games\n"
+         << std::flush;
+}
+}  // namespace raphael::datagen

--- a/src/Raphael/datagen.cpp
+++ b/src/Raphael/datagen.cpp
@@ -51,10 +51,10 @@ PackedBoard PackedBoard::pack(const chess::Board& board, i16 score) {
         const u8 col_id = static_cast<u8>((p.color() == chess::Color::WHITE) ? 0 : (1 << 3));
 
         if (p.type() == chess::PieceType::ROOK
-            && (sq.file() == cr.get_rook_file(chess::Color::WHITE, kside)
-                || sq.file() == cr.get_rook_square(chess::Color::WHITE, qside)
-                || sq.file() == cr.get_rook_square(chess::Color::BLACK, kside)
-                || sq.file() == cr.get_rook_square(chess::Color::BLACK, qside)))
+            && (sq == cr.get_rook_file(chess::Color::WHITE, kside)
+                || sq == cr.get_rook_square(chess::Color::WHITE, qside)
+                || sq == cr.get_rook_square(chess::Color::BLACK, kside)
+                || sq == cr.get_rook_square(chess::Color::BLACK, qside)))
             pt_id = unmoved_rook_id;
 
         const u8 encoding = pt_id | col_id;
@@ -65,10 +65,8 @@ PackedBoard PackedBoard::pack(const chess::Board& board, i16 score) {
     }
 
     const u8 stm_id = (board.stm() == chess::Color::WHITE) ? 0 : (1 << 7);
-    const auto enpassant = board.enpassant_square();
-    const auto rel_enpassant = (enpassant == chess::Square::NONE) ? chess::Square::NONE
-                                                                  : enpassant.relative(board.stm());
-    packed.stm_enpassant = stm_id | static_cast<u8>(rel_enpassant);
+    const auto ep_id = static_cast<u8>(board.enpassant_square());
+    packed.stm_enpassant = stm_id | ep_id;
     packed.halfmoves = board.halfmoves();
     packed.fullmoves = board.fullmoves();
     packed.eval = score;
@@ -86,9 +84,10 @@ ViriMove ViriMove::from_move(chess::Move move, i32 score) {
         static_cast<u16>(0x8000),  // castling
     };
 
-    // the move type is encoded slightly differently, so we replace it
-    virimove.move |= static_cast<u16>(move);
-    virimove.move &= 0x3FFF;
+    // encode move
+    virimove.move |= static_cast<u16>(move.from());
+    virimove.move |= static_cast<u16>(move.to()) << 6;
+    virimove.move |= static_cast<u16>(move.promotion_type() - chess::PieceType::KNIGHT) << 12;
     virimove.move |= virimovetypes[move.type() >> 14];
 
     assert(score <= INT16_MAX);
@@ -260,7 +259,11 @@ void generation_thread(
         {
             lock_guard<mutex> lock(cout_mutex);
             num_games_generated += generated;
-            cout << "\rgenerated: " + to_string(num_games_generated) + " games" << flush;
+            const auto delta
+                = ch::duration_cast<ch::milliseconds>(ch::system_clock::now() - start_time).count();
+            const auto games_persec = f64(num_games_generated) * 1000.0 / delta;
+            cout << "\rgenerated: " + to_string(num_games_generated) + " games (" << games_persec
+                 << " games/sec)" << flush;
         }
     }
 
@@ -313,9 +316,10 @@ void generate_games(
     }
 
     // get current time to use as seed
-    const auto current_time = ch::system_clock::now().time_since_epoch();
-    const auto base_seed
-        = static_cast<u64>(ch::duration_cast<ch::milliseconds>(current_time).count());
+    internal::start_time = ch::system_clock::now();
+    const auto base_seed = static_cast<u64>(
+        ch::duration_cast<ch::milliseconds>(internal::start_time.time_since_epoch()).count()
+    );
     mt19937_64 generator(base_seed);
     uniform_int_distribution<u64> distribution(0, UINT64_MAX);
 
@@ -324,7 +328,7 @@ void generate_games(
     {
         lock_guard<mutex> lock(cout_mutex);
         cout << "starting generation of " + to_string(games) + " games\n"
-             << "generated: 0 games" << flush;
+             << "generated: 0 games (0.0000 games/sec)" << flush;
     }
 
     // start generation threads

--- a/src/Raphael/datagen.cpp
+++ b/src/Raphael/datagen.cpp
@@ -329,7 +329,8 @@ void generate_games(
     internal::num_batch_remaining = (games + DATAGEN_BATCH_SIZE - 1) / DATAGEN_BATCH_SIZE;
     {
         lock_guard<mutex> lock(cout_mutex);
-        cout << "starting generation of " + to_string(games) + " games\n"
+        cout << "starting generation of " + to_string(games) + " games with "
+             << to_string(softnodes) << " softnodes, " << to_string(concurrency) << " threads\n"
              << "generated: 0 games (0.0000 games/sec)" << flush;
     }
 

--- a/src/Raphael/datagen.cpp
+++ b/src/Raphael/datagen.cpp
@@ -51,7 +51,7 @@ PackedBoard PackedBoard::pack(const chess::Board& board, i16 score) {
         const u8 col_id = static_cast<u8>((p.color() == chess::Color::WHITE) ? 0 : (1 << 3));
 
         if (p.type() == chess::PieceType::ROOK
-            && (sq == cr.get_rook_file(chess::Color::WHITE, kside)
+            && (sq == cr.get_rook_square(chess::Color::WHITE, kside)
                 || sq == cr.get_rook_square(chess::Color::WHITE, qside)
                 || sq == cr.get_rook_square(chess::Color::BLACK, kside)
                 || sq == cr.get_rook_square(chess::Color::BLACK, qside)))
@@ -215,8 +215,10 @@ void generation_thread(
                         winning_for = 0;
                         losing_for++;
                         drawing_for = 0;
-                    } else if (curr_board.fullmoves() > DATAGEN_DRAW_ADJ_MVNUM
-                               && abs(abs_score) < DATAGEN_DRAW_ADJ_SCORE) {
+                    } else if (
+                        curr_board.fullmoves() > DATAGEN_DRAW_ADJ_MVNUM
+                        && abs(abs_score) < DATAGEN_DRAW_ADJ_SCORE
+                    ) {
                         winning_for = 0;
                         losing_for = 0;
                         drawing_for++;

--- a/src/Raphael/datagen.cpp
+++ b/src/Raphael/datagen.cpp
@@ -92,7 +92,7 @@ ViriMove ViriMove::from_move(chess::Move move, i32 score) {
 
     assert(score <= INT16_MAX);
     assert(score >= INT16_MIN);
-    virimove.score = score;
+    virimove.score = static_cast<i16>(score);
 
     return virimove;
 }
@@ -228,11 +228,11 @@ void generation_thread(
                         drawing_for = 0;
                     }
 
-                    if (winning_for >= DATAGEN_WIN_ADJ_MVCNT)
+                    if (winning_for > DATAGEN_WIN_ADJ_MVCNT)
                         outcome = Outcome::WHITE_WIN;
-                    else if (losing_for >= DATAGEN_WIN_ADJ_MVCNT)
+                    else if (losing_for > DATAGEN_WIN_ADJ_MVCNT)
                         outcome = Outcome::BLACK_WIN;
-                    else if (drawing_for >= DATAGEN_DRAW_ADJ_MVCNT)
+                    else if (drawing_for > DATAGEN_DRAW_ADJ_MVCNT)
                         outcome = Outcome::DRAW;
                 }
 

--- a/src/Raphael/datagen.h
+++ b/src/Raphael/datagen.h
@@ -9,6 +9,7 @@ namespace internal {
 inline std::mutex gen_mutex;
 inline i32 num_batch_remaining = 0;
 inline i32 num_games_generated = 0;
+inline std::chrono::_V2::system_clock::time_point start_time;
 
 
 enum class Outcome : u8 { BLACK_WIN = 0, DRAW, WHITE_WIN, INVALID };

--- a/src/Raphael/datagen.h
+++ b/src/Raphael/datagen.h
@@ -38,6 +38,12 @@ struct ViriMove {
     u16 move = 0;
     u16 score = 0;
 
+    /** Packs a move and a score into a 4 byte entry
+     *
+     * \param move move to record
+     * \param score score to record
+     * \returns the packed viriformat move
+     */
     static ViriMove from_move(chess::Move move, i32 score);
 };
 static_assert(sizeof(ViriMove) == 4);

--- a/src/Raphael/datagen.h
+++ b/src/Raphael/datagen.h
@@ -1,0 +1,91 @@
+#include <Raphael/Raphael.h>
+
+#include <mutex>
+
+
+
+namespace raphael::datagen {
+namespace internal {
+inline std::mutex gen_mutex;
+inline i32 num_batch_remaining = 0;
+inline i32 num_games_generated = 0;
+
+
+enum class Outcome : u8 { BLACK_WIN = 0, DRAW, WHITE_WIN, INVALID };
+
+struct PackedBoard {
+    u64 occ;
+    u8 pieces[32 / 2] = {0};
+    u8 stm_enpassant;
+    u8 halfmoves;
+    u16 fullmoves;
+    i16 eval;
+    Outcome outcome;
+    u8 pad = 0;
+
+    /** Packs a board into a 32 byte entry
+     *
+     * \param board board to pack
+     * \param score score to record
+     * \returns the packed board
+     */
+    static PackedBoard pack(const chess::Board& board, i16 score);
+};
+static_assert(sizeof(PackedBoard) == 32);
+
+struct ViriMove {
+    u16 move = 0;
+    u16 score = 0;
+
+    static ViriMove from_move(chess::Move move, i32 score);
+};
+static_assert(sizeof(ViriMove) == 4);
+
+
+/** Thread function to generate games until num_batch_remaining is 0
+ *
+ * \param engine pointer to engine or nullptr to internally create one
+ * \param softnodes number of softnodes to use
+ * \param seed_fens positions from the opening book
+ * \param filename output filename to write to
+ * \param seed rng seed to use
+ * \param randmoves number of random moves to play on top of the book
+ * \param dfrc whether to use DFRC positions
+ */
+void generation_thread(
+    Raphael* engine,
+    i32 softnodes,
+    std::vector<std::string> seed_fens,
+    std::string filename,
+    u64 seed,
+    i32 randmoves,
+    bool dfrc
+);
+
+
+/** Gracefully terminates the datagen */
+void handle_interrupt(i32);
+}  // namespace internal
+
+
+
+/** Generates games for training data
+ *
+ * \param main_engine engine used by the first thread
+ * \param softnodes number of softnodes to use
+ * \param games minimum number of games to generate
+ * \param book book to use
+ * \param randmoves number of random moves to play on top of the book
+ * \param dfrc whether to use DFRC positions
+ * \param concurrency number of threads to use
+ */
+void generate_games(
+    Raphael& main_engine,
+    i32 softnodes,
+    i32 games,
+    const std::string& book,
+    i32 randmoves,
+    bool dfrc,
+    i32 concurrency
+);
+}  // namespace raphael::datagen

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -313,7 +313,7 @@ static constexpr i32 DATAGEN_DRAW_ADJ_MVNUM = 32;
 static constexpr i32 DATAGEN_DRAW_ADJ_MVCNT = 6;
 static constexpr i32 DATAGEN_DRAW_ADJ_SCORE = 15;
 static constexpr i32 DATAGEN_HASH = 16;
-static constexpr i32 DATAGEN_BATCH_SIZE = 1;
+static constexpr i32 DATAGEN_BATCH_SIZE = 32;
 
 static constexpr f64 DEF_TARGET_ABS_MEAN = 491.0081;  // average for lichess-big3-resolved
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -307,6 +307,14 @@ static constexpr i32 BENCH_DEPTH = 14;
 static constexpr i32 GENFENS_MAX_NODES = 1000;
 static constexpr i32 GENFENS_MAX_SCORE = 1000;
 
+static constexpr i32 DATAGEN_WIN_ADJ_MVCNT = 5;
+static constexpr i32 DATAGEN_WIN_ADJ_SCORE = 2000;
+static constexpr i32 DATAGEN_DRAW_ADJ_MVNUM = 32;
+static constexpr i32 DATAGEN_DRAW_ADJ_MVCNT = 6;
+static constexpr i32 DATAGEN_DRAW_ADJ_SCORE = 15;
+static constexpr i32 DATAGEN_HASH = 16;
+static constexpr i32 DATAGEN_BATCH_SIZE = 1;
+
 static constexpr f64 DEF_TARGET_ABS_MEAN = 491.0081;  // average for lichess-big3-resolved
 
 

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -48,6 +48,12 @@ public:
             return File((rooks_ >> shift) & 0xF);
         }
 
+        [[nodiscard]] constexpr Square get_rook_square(Color color, Side castle) const {
+            const auto file = get_rook_file(color, castle);
+            const auto rank = Rank(color * 7);
+            return Square(file, rank);
+        }
+
         [[nodiscard]] constexpr i32 hash_index() const {
             return has(Color::WHITE, Side::KING_SIDE) + 2 * has(Color::WHITE, Side::QUEEN_SIDE)
                    + 4 * has(Color::BLACK, Side::KING_SIDE)

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -50,6 +50,7 @@ public:
 
         [[nodiscard]] constexpr Square get_rook_square(Color color, Side castle) const {
             const auto file = get_rook_file(color, castle);
+            if (file == File::NONE) return Square::NONE;
             const auto rank = Rank(color * 7);
             return Square(file, rank);
         }

--- a/uci.cpp
+++ b/uci.cpp
@@ -506,7 +506,7 @@ inline void show_help() {
          << "      BOOK: book to start with. defualt is None, AKA startpos\n"
          << "      RANDMOVES: number of random moves to play from book position. default 0\n"
          << "      DFRC: whether to generate DFRC positions, true/false. default false\n"
-         << "      THReADS: number of threads to generate with\n\n"
+         << "      THREADS: number of threads to generate with\n\n"
          << "  evalstats <BOOK>\n"
          << "      print statistics of NNUE evaluation\n"
          << "      BOOK: book to benchmark with\n\n"

--- a/uci.cpp
+++ b/uci.cpp
@@ -1,6 +1,7 @@
 #include <GameEngine/consts.h>
 #include <Raphael/Raphael.h>
 #include <Raphael/commands.h>
+#include <Raphael/datagen.h>
 #include <Raphael/tunable.h>
 
 #include <condition_variable>
@@ -390,6 +391,75 @@ inline void handle_genfens(const vector<string>& tokens) {
     search_cv.notify_one();
 }
 
+/** Handles the datagen command
+ *
+ * \param tokens list of tokens for the command
+ */
+inline void handle_datagen(const vector<string>& tokens) {
+    lock_guard<mutex> search_lock(search_mutex);
+    if (pending_request.searching) {
+        lock_guard<mutex> lock(cout_mutex);
+        cout << "info string still searching\n" << flush;
+        return;
+    }
+
+    if (tokens.size() < 3) {
+        cout << "info string missing required positional parameters 'softnodes' and 'games'\n"
+             << flush;
+        return;
+    }
+
+    i32 softnodes = stoi(tokens[1]);
+    i32 games = stoi(tokens[2]);
+    std::string book = "None";
+    i32 randmoves = 0;
+    bool dfrc = false;
+    i32 concurrency = 1;
+
+    usize i = 3;
+    while (i < tokens.size()) {
+        if (tokens[i] == "book")
+            book = tokens[i + 1];
+        else if (tokens[i] == "randmoves")
+            randmoves = stoi(tokens[i + 1]);
+        else if (tokens[i] == "dfrc")
+            dfrc = (tokens[i + 1] == "true");
+        else if (tokens[i] == "threads")
+            concurrency = stoi(tokens[i + 1]);
+        i += 2;
+    }
+
+    if (softnodes <= 0) {
+        lock_guard<mutex> lock(cout_mutex);
+        cout << "info string softnodes must be positive\n" << flush;
+        return;
+    }
+
+    if (games <= 0) {
+        lock_guard<mutex> lock(cout_mutex);
+        cout << "info string count must be positive\n" << flush;
+        return;
+    }
+
+    if (randmoves < 0) {
+        lock_guard<mutex> lock(cout_mutex);
+        cout << "info string randmoves must be non-negative\n" << flush;
+        return;
+    }
+
+    if (concurrency <= 0) {
+        lock_guard<mutex> lock(cout_mutex);
+        cout << "info string threads must be positive\n" << flush;
+        return;
+    }
+
+    raphael::datagen::generate_games(engine, softnodes, games, book, randmoves, dfrc, concurrency);
+
+    // quit
+    quit.store(true, memory_order_relaxed);
+    search_cv.notify_one();
+}
+
 /** Handles the evalstats command
  *
  * \param tokens list of tokens for the command
@@ -428,7 +498,16 @@ inline void show_help() {
          << "      SEED: random seed, u64. default 0\n"
          << "      BOOK: book to start with. default is None, AKA startpos\n"
          << "      RANDMOVES: number of random moves to play from book position. default 0\n"
-         << "      DFCR: whether to generate DFRC positions, true/false. default false\n\n"
+         << "      DFRC: whether to generate DFRC positions, true/false. default false\n\n"
+         << " datagen <SOFTNODES> <GAMES> [book BOOK] [randmoves RANDMOVES] [dfrc DFRC] [threads "
+            "THREADS]\n"
+         << "      generate training data\n"
+         << "      SOFTNODES: number of softnodes to generate with\n"
+         << "      GAMES: number of games to generate\n"
+         << "      BOOK: book to start with. defualt is None, AKA startpos\n"
+         << "      RANDMOVES: number of random moves to play from book position. default 0\n"
+         << "      DFRC: whether to generate DFRC positions, true/false. default false\n"
+         << "      THReADS: number of threads to generate with\n\n"
          << "  evalstats <BOOK>\n"
          << "      print statistics of NNUE evaluation\n"
          << "      BOOK: book to benchmark with\n\n"
@@ -532,6 +611,9 @@ inline void handle_command(const string& uci_command) {
 
         else if (keyword == "genfens")
             handle_genfens(tokens);
+
+        else if (keyword == "datagen")
+            handle_datagen(tokens);
 
         else if (keyword == "evalstats")
             handle_evalstats(tokens);

--- a/uci.cpp
+++ b/uci.cpp
@@ -1,5 +1,4 @@
 #include <GameEngine/consts.h>
-#include <Raphael/Raphael.h>
 #include <Raphael/commands.h>
 #include <Raphael/datagen.h>
 #include <Raphael/tunable.h>


### PR DESCRIPTION
Added custom datagen script.
Thanks @JonathanHallstrom for helping me out a ton in debugging the viriformat writer!

Games/sec is roughly 23% faster compared to OpenBench on the same machine. 
64hl net trained on new data loses elo though...

```
Elo   | -3.77 +- 2.80 (95%)
SPRT  | N=25000 Threads=1 Hash=16MB
LLR   | -3.49 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 34156 W: 11249 L: 11620 D: 11287
Penta | [1616, 3720, 6627, 3649, 1466]
```
https://rmeguro.pythonanywhere.com/test/226/