### PR TITLE
feat: no sharing history and tt in datagen

### DIFF
--- a/src/Raphael/datagen.cpp
+++ b/src/Raphael/datagen.cpp
@@ -107,18 +107,22 @@ void generation_thread(
     i32 randmoves,
     bool dfrc
 ) {
-    // create engine if not passed
+    // create engines for both sides
+    Raphael* engines[2] = {engine, nullptr};
     bool created_engine = false;
     if (engine == nullptr) {
-        engine = new Raphael("Raphael");
+        engines[0] = new Raphael("Raphael");
         created_engine = true;
     }
+    engines[1] = new Raphael("Raphael");
 
-    // initialize engine
-    engine->set_uciinfolevel(raphael::Raphael::UciInfoLevel::NONE);
-    engine->set_option("Softnodes", true);
-    engine->set_option("Hash", DATAGEN_HASH);
-    engine->set_option("Threads", 1);
+    // initialize engines
+    for (i32 i = 0; i < 2; i++) {
+        engines[i]->set_uciinfolevel(raphael::Raphael::UciInfoLevel::NONE);
+        engines[i]->set_option("Softnodes", true);
+        engines[i]->set_option("Hash", DATAGEN_HASH);
+        engines[i]->set_option("Threads", 1);
+    }
 
     // initialize other stuff
     ofstream outfile(filename);
@@ -158,22 +162,26 @@ void generation_thread(
 
             // filter unbalanced/illegal positions
             halt.store(false, memory_order_relaxed);
-            engine->reset();
-            engine->set_searchoptions({.maxnodes = GENFENS_MAX_NODES});
-            engine->set_board(board);
-            const auto res = engine->get_move(0, 0, halt);
+            engines[0]->reset();
+            engines[0]->set_searchoptions({.maxnodes = GENFENS_MAX_NODES});
+            engines[0]->set_board(board);
+            const auto res = engines[0]->get_move(0, 0, halt);
             if (res.move == chess::Move::NO_MOVE || res.is_mate
                 || abs(res.score) > GENFENS_MAX_SCORE)
                 continue;
 
             // play from here
-            engine->set_searchoptions({.maxnodes = softnodes});
+            for (i32 i = 0; i < 2; i++) {
+                engines[0]->reset();
+                engines[0]->set_searchoptions({.maxnodes = softnodes});
+            }
             position.set_board(board);
 
             auto packed = PackedBoard::pack(board, 0);
             vector<ViriMove> movescores;
             movescores.reserve(256);
             Outcome outcome = Outcome::INVALID;
+            bool side = false;
             i32 winning_for = 0;
             i32 losing_for = 0;
             i32 drawing_for = 0;
@@ -183,8 +191,8 @@ void generation_thread(
                 const auto stm = curr_board.stm();
 
                 halt.store(false, memory_order_relaxed);
-                engine->set_position(position);
-                const auto res = engine->get_move(0, 0, halt);
+                engines[side]->set_position(position);
+                const auto res = engines[side]->get_move(0, 0, halt);
                 auto abs_score = (stm == chess::Color::WHITE) ? res.score : -res.score;
 
                 // handle terminal state
@@ -237,6 +245,7 @@ void generation_thread(
                 }
 
                 position.make_move(res.move);
+                side = !side;
 
                 // handle draws
                 if (curr_board.is_halfmovedraw() || curr_board.is_insufficientmaterial()
@@ -270,7 +279,8 @@ void generation_thread(
     }
 
     outfile.close();
-    if (created_engine) delete engine;
+    if (created_engine) delete engines[0];
+    delete engines[1];
 }
 
 

--- a/src/Raphael/datagen.cpp
+++ b/src/Raphael/datagen.cpp
@@ -172,8 +172,8 @@ void generation_thread(
 
             // play from here
             for (i32 i = 0; i < 2; i++) {
-                engines[0]->reset();
-                engines[0]->set_searchoptions({.maxnodes = softnodes});
+                engines[i]->reset();
+                engines[i]->set_searchoptions({.maxnodes = softnodes});
             }
             position.set_board(board);
 

--- a/src/Raphael/datagen.cpp
+++ b/src/Raphael/datagen.cpp
@@ -181,7 +181,6 @@ void generation_thread(
             vector<ViriMove> movescores;
             movescores.reserve(256);
             Outcome outcome = Outcome::INVALID;
-            bool side = false;
             i32 winning_for = 0;
             i32 losing_for = 0;
             i32 drawing_for = 0;
@@ -191,8 +190,8 @@ void generation_thread(
                 const auto stm = curr_board.stm();
 
                 halt.store(false, memory_order_relaxed);
-                engines[side]->set_position(position);
-                const auto res = engines[side]->get_move(0, 0, halt);
+                engines[stm]->set_position(position);
+                const auto res = engines[stm]->get_move(0, 0, halt);
                 auto abs_score = (stm == chess::Color::WHITE) ? res.score : -res.score;
 
                 // handle terminal state
@@ -245,7 +244,6 @@ void generation_thread(
                 }
 
                 position.make_move(res.move);
-                side = !side;
 
                 // handle draws
                 if (curr_board.is_halfmovedraw() || curr_board.is_insufficientmaterial()


### PR DESCRIPTION
compared to the openbench data
```
Elo   | 5.78 +- 5.85 (95%)
SPRT  | N=25000 Threads=1 Hash=16MB
LLR   | 3.34 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 8052 W: 2723 L: 2589 D: 2740
Penta | [363, 852, 1478, 954, 379]
```
https://rmeguro.pythonanywhere.com/test/228/