### PR TITLE
feat: don't do qsfp if a move directly gives check

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -375,7 +375,8 @@ i32 Raphael::negamax(
 
                 // futility pruning
                 const i32 futility = ss->static_eval + FP_MARGIN_BASE + FP_DEPTH_SCALE * lmr_depth;
-                if (!in_check && lmr_depth <= FP_DEPTH && futility <= alpha) {
+                if (!in_check && lmr_depth <= FP_DEPTH && futility <= alpha
+                    && !board.gives_direct_check(move)) {
                     generator.skip_quiets();
                     continue;
                 }

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -375,8 +375,7 @@ i32 Raphael::negamax(
 
                 // futility pruning
                 const i32 futility = ss->static_eval + FP_MARGIN_BASE + FP_DEPTH_SCALE * lmr_depth;
-                if (!in_check && lmr_depth <= FP_DEPTH && futility <= alpha
-                    && !board.gives_direct_check(move)) {
+                if (!in_check && lmr_depth <= FP_DEPTH && futility <= alpha) {
                     generator.skip_quiets();
                     continue;
                 }
@@ -590,7 +589,8 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
             if (move_searched >= QS_MAX_MOVES) break;
 
             // qs futility pruning
-            if (!in_check && futility <= alpha && !SEE::see(move, board, 1)) {
+            if (!in_check && futility <= alpha && !board.gives_direct_check(move)
+                && !SEE::see(move, board, 1)) {
                 bestscore = max(bestscore, futility);
                 continue;
             }

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -368,7 +368,8 @@ i32 Raphael::negamax(
 
             if (is_quiet) {
                 // late move pruning
-                if (move_searched >= LMP_TABLE[improving][depth]) {
+                if (move_searched >= LMP_TABLE[improving][depth]
+                    && !board.gives_direct_check(move)) {
                     generator.skip_quiets();
                     continue;
                 }

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -368,8 +368,7 @@ i32 Raphael::negamax(
 
             if (is_quiet) {
                 // late move pruning
-                if (move_searched >= LMP_TABLE[improving][depth]
-                    && !board.gives_direct_check(move)) {
+                if (move_searched >= LMP_TABLE[improving][depth] + board.gives_direct_check(move)) {
                     generator.skip_quiets();
                     continue;
                 }

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -368,7 +368,7 @@ i32 Raphael::negamax(
 
             if (is_quiet) {
                 // late move pruning
-                if (move_searched >= LMP_TABLE[improving][depth] + board.gives_direct_check(move)) {
+                if (move_searched >= LMP_TABLE[improving][depth]) {
                     generator.skip_quiets();
                     continue;
                 }


### PR DESCRIPTION
https://furybench.com/test/5686/
```
Elo   | 5.18 +- 3.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9658 W: 2332 L: 2188 D: 5138
Penta | [27, 1113, 2415, 1237, 37]
```
https://rmeguro.pythonanywhere.com/test/236/
bench: 7976239