### PR TITLE
feat: store static eval

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -283,9 +283,10 @@ i32 Raphael::negamax(
     // probe transposition table
     const auto ttkey = board.hash();
     auto ttentry = TranspositionTable::ProbedEntry();
+    bool tthit = false;
 
     if (!ss->excluded) {
-        const bool tthit = tt_.get(ttentry, ttkey, ply);
+        tthit = tt_.get(ttentry, ttkey, ply);
 
         // tt cutoff
         if (!is_PV && tthit && ttentry.depth >= depth
@@ -301,8 +302,21 @@ i32 Raphael::negamax(
     if (depth >= IIR_DEPTH && !ss->excluded && (is_PV || cutnode) && !ttmove) depth--;
 
     const bool in_check = board.in_check();
-    if (!ss->excluded)
-        ss->static_eval = (in_check) ? NONE_SCORE : history_.correct(board, position_.evaluate());
+    i32 raw_static_eval;
+
+    if (!ss->excluded) {
+        if (in_check) {
+            raw_static_eval = NONE_SCORE;
+            ss->static_eval = NONE_SCORE;
+        } else {
+            if (tthit && ttentry.static_eval != NONE_SCORE)
+                raw_static_eval = ttentry.static_eval;
+            else
+                raw_static_eval = position_.evaluate();
+
+            ss->static_eval = history_.correct(board, raw_static_eval);
+        }
+    }
     const bool improving = !in_check && ss->static_eval > (ss - 2)->static_eval;
 
     // pre-moveloop pruning
@@ -524,7 +538,7 @@ i32 Raphael::negamax(
             && (ttflag == tt_.EXACT || (ttflag == tt_.LOWER && bestscore > ss->static_eval)
                 || (ttflag == tt_.UPPER && bestscore < ss->static_eval)))
             history_.update_corrections(board, depth, bestscore, ss->static_eval);
-        tt_.set(ttkey, bestscore, bestmove, depth, ttflag, ply);
+        tt_.set(ttkey, bestscore, raw_static_eval, bestmove, depth, ttflag, ply);
     }
 
     return bestscore;
@@ -558,11 +572,19 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
         return ttentry.score;
 
     // standing pat
+    i32 raw_static_eval;
     i32 static_eval;
-    if (in_check)
+
+    if (in_check) {
+        raw_static_eval = NONE_SCORE;
         static_eval = -MATE_SCORE + ply;
-    else {
-        static_eval = history_.correct(board, position_.evaluate());
+    } else {
+        if (tthit && ttentry.static_eval != NONE_SCORE)
+            raw_static_eval = ttentry.static_eval;
+        else
+            raw_static_eval = position_.evaluate();
+
+        static_eval = history_.correct(board, raw_static_eval);
 
         if (static_eval >= beta) return static_eval;
 
@@ -630,7 +652,8 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
     if (in_check && move_searched == 0) return -MATE_SCORE + ply;
 
     // update transposition table
-    if (!halt.load(memory_order_relaxed)) tt_.set(ttkey, bestscore, bestmove, 0, ttflag, ply);
+    if (!halt.load(memory_order_relaxed))
+        tt_.set(ttkey, bestscore, raw_static_eval, bestmove, 0, ttflag, ply);
 
     return bestscore;
 }

--- a/src/Raphael/Transposition.cpp
+++ b/src/Raphael/Transposition.cpp
@@ -60,6 +60,7 @@ bool TranspositionTable::get(ProbedEntry& ttentry, u64 key, i32 ply) const {
         else if (utils::is_win(score))
             score -= ply;
         ttentry.score = score;
+        ttentry.static_eval = static_cast<i32>(entry.static_eval);
         ttentry.move = static_cast<chess::Move>(entry.move);
         ttentry.depth = static_cast<i32>(entry.depth);
         ttentry.flag = entry.flag();
@@ -72,7 +73,9 @@ bool TranspositionTable::get(ProbedEntry& ttentry, u64 key, i32 ply) const {
 
 void TranspositionTable::prefetch(u64 key) const { __builtin_prefetch(&table_[index(key)]); }
 
-void TranspositionTable::set(u64 key, i32 score, chess::Move move, i32 depth, Flag flag, i32 ply) {
+void TranspositionTable::set(
+    u64 key, i32 score, i32 static_eval, chess::Move move, i32 depth, Flag flag, i32 ply
+) {
     assert(depth >= 0);
     assert(depth < 256);
 
@@ -93,10 +96,13 @@ void TranspositionTable::set(u64 key, i32 score, chess::Move move, i32 depth, Fl
 
     assert(score >= INT16_MIN);
     assert(score <= INT16_MAX);
+    assert(static_eval >= INT16_MIN);
+    assert(static_eval <= INT16_MAX);
 
     // set
     entry.key = packed_key;
     entry.score = static_cast<i16>(score);
+    entry.static_eval = static_cast<i16>(static_eval);
     entry.depth = static_cast<u8>(depth);
     entry.set_age_flag(age_, flag);
 

--- a/src/Raphael/Transposition.h
+++ b/src/Raphael/Transposition.h
@@ -14,11 +14,12 @@ public:
     enum Flag : u8 { INVALID = 0, LOWER, EXACT, UPPER };
 
     struct Entry {
-        u16 key;      // zobrist hash of position
-        i16 score;    // score of the position
-        u16 move;     // bestmove
-        u8 depth;     // max 255
-        u8 age_flag;  // 6 bits age, 2 bits flag
+        u16 key;          // zobrist hash of position
+        i16 score;        // score of the position
+        i16 static_eval;  // static eval of the position
+        u16 move;         // bestmove
+        u8 depth;         // max 255
+        u8 age_flag;      // 6 bits age, 2 bits flag
 
         u32 age() const;
         Flag flag() const;
@@ -26,10 +27,11 @@ public:
         void set_age_flag(u32 age, Flag flag);
     };
     static constexpr usize ENTRY_SIZE = sizeof(Entry);
-    static_assert(ENTRY_SIZE == 8);
+    static_assert(ENTRY_SIZE == 10);
 
     struct ProbedEntry {
         i32 score;
+        i32 static_eval;
         i32 depth;
         chess::Move move;
         Flag flag;
@@ -82,12 +84,13 @@ public:
      *
      * \param key zobrist hash of position
      * \param score score of the position
+     * \param static_eval static eval of the position
      * \param move bestmove
      * \param depth max 255
      * \param flag invalid, lower, exact, or upper
      * \param ply current distance from root
      */
-    void set(u64 key, i32 score, chess::Move move, i32 depth, Flag flag, i32 ply);
+    void set(u64 key, i32 score, i32 static_eval, chess::Move move, i32 depth, Flag flag, i32 ply);
 
     /** Clears the table */
     void clear();


### PR DESCRIPTION
```
Elo   | 2.88 +- 2.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 5.00]
Games | N: 24014 W: 5850 L: 5651 D: 12513
Penta | [70, 2818, 6060, 2961, 98]
```
https://rmeguro.pythonanywhere.com/test/244/
bench: 8667819