### PR TITLE
feat: half s_beta if tt exact

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -406,7 +406,10 @@ i32 Raphael::negamax(
         i32 extension = 0;
         if (!is_root && depth >= SE_DEPTH && move == ttmove && !ss->excluded
             && ttentry.depth >= depth - SE_TT_DEPTH && ttentry.flag != tt_.UPPER) {
-            const i32 s_beta = max(-MATE_SCORE + 1, ttentry.score - depth * SE_DEPTH_MARGIN / 16);
+            const i32 s_beta = max(
+                -MATE_SCORE + 1,
+                ttentry.score - depth * SE_DEPTH_MARGIN * ((ttentry.flag == tt_.EXACT) ? 1 : 2) / 16
+            );
             const i32 s_depth = (depth - 1) / 2;
 
             ss->excluded = move;

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -236,7 +236,7 @@ Tunable(SEE_NOISY_DEPTH_SCALE, -90, -128, -30, true);  // depth scale for noisy 
 
 Tunable(SE_DEPTH, 8, 6, 12, true);          // min depth to apply singular extensions from
 Tunable(SE_TT_DEPTH, 3, 3, 6, true);        // min tt depth margin for singular extensions
-Tunable(SE_DEPTH_MARGIN, 32, 4, 64, true);  // depth margin for singular extension beta
+Tunable(SE_DEPTH_MARGIN, 16, 4, 64, true);  // depth margin for singular extension beta
 Tunable(DE_MARGIN, 30, 4, 64, true);        // score margin for double extensions
 
 Tunable(LMR_DEPTH, 3, 1, 5, true);              // depth to apply lmr from


### PR DESCRIPTION
cj patch in reckless

```
Elo   | 4.55 +- 3.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11756 W: 2883 L: 2729 D: 6144
Penta | [41, 1335, 2976, 1481, 45]
```
https://rmeguro.pythonanywhere.com/test/248/
bench: 9641565