### PR TITLE
feat: reduce more when deeper in nmp

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -339,7 +339,8 @@ i32 Raphael::negamax(
             position_.make_nullmove();
             ss->move = chess::Move::NULL_MOVE;
 
-            const i32 red_depth = depth - NMP_REDUCTION;
+            const i32 red_factor = NMP_REDUCTION + depth * NMP_DEPTH_SCALE;
+            const i32 red_depth = depth - red_factor / 128;
             const i32 score = -negamax<false>(
                 red_depth, ply + 1, mvidx, -beta, -beta + 1, !cutnode, ss + 1, halt
             );

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -223,8 +223,9 @@ Tunable(RAZORING_DEPTH, 4, 1, 10, true);             // max depth to apply razor
 Tunable(RAZORING_DEPTH_SCALE, 250, 100, 350, true);  // margin depth scale for razoring
 Tunable(RAZORING_MARGIN_BASE, 300, 0, 400, true);    // base margin for razoring
 
-Tunable(NMP_DEPTH, 3, 1, 10, true);      // depth to apply nmp from
-Tunable(NMP_REDUCTION, 4, 1, 10, true);  // depth reduction for nmp
+Tunable(NMP_DEPTH, 3, 1, 10, true);           // depth to apply nmp from
+Tunable(NMP_REDUCTION, 512, 32, 1024, true);  // depth reduction for nmp
+Tunable(NMP_DEPTH_SCALE, 25, 1, 64, true);    // depth scale for nmp reduction
 
 inline MultiArray<i32, 2, 256> LMP_TABLE;  // lmp threshold[improving][depth]
 TunableCallback(LMP_THRESH_BASE, 3, 1, 12, update_lmp_table, true);


### PR DESCRIPTION
stc
```
Elo   | 13.90 +- 6.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2976 W: 764 L: 645 D: 1567
Penta | [5, 327, 714, 428, 14]
```
https://rmeguro.pythonanywhere.com/test/254/

ltc
```
Elo   | 23.41 +- 8.50 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1650 W: 467 L: 356 D: 827
Penta | [0, 155, 410, 254, 6]
```
https://rmeguro.pythonanywhere.com/test/255/

bench: 7744294