### PR TITLE
feat: reduce more in nmp if static eval is far above beta

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -339,7 +339,10 @@ i32 Raphael::negamax(
             position_.make_nullmove();
             ss->move = chess::Move::NULL_MOVE;
 
-            const i32 red_factor = NMP_REDUCTION + depth * NMP_DEPTH_SCALE;
+            i32 red_factor = NMP_REDUCTION;
+            red_factor += depth * NMP_DEPTH_SCALE;
+            red_factor += min((ss->static_eval - beta) * NMP_EVAL_SCALE, NMP_EVAL_MAX);
+
             const i32 red_depth = depth - red_factor / 128;
             const i32 score = -negamax<false>(
                 red_depth, ply + 1, mvidx, -beta, -beta + 1, !cutnode, ss + 1, halt

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -225,7 +225,9 @@ Tunable(RAZORING_MARGIN_BASE, 300, 0, 400, true);    // base margin for razoring
 
 Tunable(NMP_DEPTH, 3, 1, 10, true);           // depth to apply nmp from
 Tunable(NMP_REDUCTION, 512, 32, 1024, true);  // depth reduction for nmp
-Tunable(NMP_DEPTH_SCALE, 25, 1, 64, true);    // depth scale for nmp reduction
+Tunable(NMP_DEPTH_SCALE, 25, 1, 128, true);   // depth scale for nmp reduction
+Tunable(NMP_EVAL_SCALE, 82, 1, 128, true);    // eval minus beta scale for nmp reduction
+Tunable(NMP_EVAL_MAX, 384, 32, 1024, true);   // max eval minus beta nmp reduction
 
 inline MultiArray<i32, 2, 256> LMP_TABLE;  // lmp threshold[improving][depth]
 TunableCallback(LMP_THRESH_BASE, 3, 1, 12, update_lmp_table, true);


### PR DESCRIPTION
```
Elo   | 6.21 +- 4.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7436 W: 1786 L: 1653 D: 3997
Penta | [14, 842, 1879, 963, 20]
```
https://rmeguro.pythonanywhere.com/test/256/
bench: 6853598