### PR TITLE
feat: material eval scaling

### DIFF
--- a/src/Raphael/History.h
+++ b/src/Raphael/History.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <Raphael/position.h>
-#include <Raphael/tunable.h>
 
 
 

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -205,7 +205,7 @@ void Raphael::ponder(atomic<bool>& halt) {
 
 
 i32 Raphael::static_eval(bool corrected) {
-    const auto raw_score = position_.evaluate();
+    const auto raw_score = position_.evaluate(!params_.datagen);
     return (corrected) ? history_.correct(position_.board(), raw_score) : raw_score;
 }
 
@@ -312,7 +312,7 @@ i32 Raphael::negamax(
             if (tthit && ttentry.static_eval != NONE_SCORE)
                 raw_static_eval = ttentry.static_eval;
             else
-                raw_static_eval = position_.evaluate();
+                raw_static_eval = position_.evaluate(!params_.datagen);
 
             ss->static_eval = history_.correct(board, raw_static_eval);
         }
@@ -565,7 +565,8 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
 
     // max ply
     const bool in_check = board.in_check();
-    if (ply >= MAX_DEPTH - 1) return (in_check) ? 0 : history_.correct(board, position_.evaluate());
+    if (ply >= MAX_DEPTH - 1)
+        return (in_check) ? 0 : history_.correct(board, position_.evaluate(!params_.datagen));
 
     // probe transposition table
     const auto ttkey = board.hash();
@@ -592,7 +593,7 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
         if (tthit && ttentry.static_eval != NONE_SCORE)
             raw_static_eval = ttentry.static_eval;
         else
-            raw_static_eval = position_.evaluate();
+            raw_static_eval = position_.evaluate(!params_.datagen);
 
         static_eval = history_.correct(board, raw_static_eval);
 

--- a/src/Raphael/Raphael.h
+++ b/src/Raphael/Raphael.h
@@ -3,7 +3,6 @@
 #include <Raphael/Transposition.h>
 #include <Raphael/position.h>
 #include <Raphael/tm.h>
-#include <Raphael/tunable.h>
 
 #include <atomic>
 #include <string>

--- a/src/Raphael/position.h
+++ b/src/Raphael/position.h
@@ -105,7 +105,8 @@ public:
         i32 static_eval = net_.evaluate(current_);
         if (do_scaling) {
             const i32 material_scale
-                = MAT_SCALE_BASE + current_.occ(chess::PieceType::KNIGHT).count() * MAT_SCALE_KNIGHT
+                = MAT_SCALE_BASE + current_.occ(chess::PieceType::PAWN).count() * MAT_SCALE_PAWN
+                  + current_.occ(chess::PieceType::KNIGHT).count() * MAT_SCALE_KNIGHT
                   + current_.occ(chess::PieceType::BISHOP).count() * MAT_SCALE_BISHOP
                   + current_.occ(chess::PieceType::ROOK).count() * MAT_SCALE_ROOK
                   + current_.occ(chess::PieceType::QUEEN).count() * MAT_SCALE_QUEEN;

--- a/src/Raphael/position.h
+++ b/src/Raphael/position.h
@@ -2,6 +2,7 @@
 #include <Raphael/nnue.h>
 #include <Raphael/tunable.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <type_traits>
 

--- a/src/Raphael/position.h
+++ b/src/Raphael/position.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Raphael/nnue.h>
+#include <Raphael/tunable.h>
 
 #include <cstddef>
 #include <type_traits>
@@ -94,12 +95,22 @@ public:
 
     /** Evaluates the current board from the current side to move
      *
+     * \param do_scaling whether to apply material scaling
      * \returns the NNUE evaluation of the board in centipawns
      */
-    i32 evaluate()
+    i32 evaluate(bool do_scaling)
         requires(include_net)
     {
-        return net_.evaluate(current_);
+        i32 static_eval = net_.evaluate(current_);
+        if (do_scaling) {
+            const i32 material_scale
+                = MAT_SCALE_BASE + current_.occ(chess::PieceType::KNIGHT).count() * MAT_SCALE_KNIGHT
+                  + current_.occ(chess::PieceType::BISHOP).count() * MAT_SCALE_BISHOP
+                  + current_.occ(chess::PieceType::ROOK).count() * MAT_SCALE_ROOK
+                  + current_.occ(chess::PieceType::QUEEN).count() * MAT_SCALE_QUEEN;
+            static_eval = static_eval * material_scale / 32768;
+        }
+        return std::clamp(static_eval, -MATE_SCORE + 1, MATE_SCORE - 1);
     }
 
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -306,6 +306,13 @@ Tunable(PAWN_CORRHIST_WEIGHT, 56, 32, 384, true);
 Tunable(MAJOR_CORRHIST_WEIGHT, 48, 32, 384, true);
 Tunable(NONPAWN_CORRHIST_WEIGHT, 48, 32, 384, true);
 
+// eval scaling
+Tunable(MAT_SCALE_BASE, 25100, 20000, 30000, true);
+Tunable(MAT_SCALE_KNIGHT, 340, 200, 600, true);
+Tunable(MAT_SCALE_BISHOP, 340, 200, 600, true);
+Tunable(MAT_SCALE_ROOK, 590, 400, 900, true);
+Tunable(MAT_SCALE_QUEEN, 970, 800, 1600, true);
+
 // commands
 static constexpr i32 BENCH_DEPTH = 14;
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -308,6 +308,7 @@ Tunable(NONPAWN_CORRHIST_WEIGHT, 48, 32, 384, true);
 
 // eval scaling
 Tunable(MAT_SCALE_BASE, 25100, 20000, 30000, true);
+Tunable(MAT_SCALE_PAWN, 110, 0, 200, true);
 Tunable(MAT_SCALE_KNIGHT, 340, 200, 600, true);
 Tunable(MAT_SCALE_BISHOP, 340, 200, 600, true);
 Tunable(MAT_SCALE_ROOK, 590, 400, 900, true);

--- a/src/tests/position.cpp
+++ b/src/tests/position.cpp
@@ -26,7 +26,7 @@ public:
 
         for (const auto& smove : moves) {
             position_.make_move(smove.move);
-            const auto eval = position_.evaluate();
+            const auto eval = position_.evaluate(false);
 
             const auto& newboard = position_.board();
             refnet_.set_board(newboard);
@@ -48,7 +48,7 @@ public:
 
         // check nullmove
         position_.make_nullmove();
-        const auto eval = position_.evaluate();
+        const auto eval = position_.evaluate(false);
 
         const auto& newboard = position_.board();
         refnet_.set_board(newboard);


### PR DESCRIPTION
```
Elo   | 9.82 +- 15.38 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.34 (-2.25, 2.89) [0.00, 5.00]
Games | N: 460 W: 113 L: 100 D: 247
Penta | [0, 47, 123, 60, 0]
```
https://rmeguro.pythonanywhere.com/test/273/
bench: 6936710