### PR TITLE
feat: 1-ply contcorrhist

### DIFF
--- a/src/Raphael/History.cpp
+++ b/src/Raphael/History.cpp
@@ -42,7 +42,8 @@ History::History()
       capt_hist_{},
       pawn_correction_{},
       major_correction_{},
-      nonpawn_correction_{} {}
+      nonpawn_correction_{},
+      cont_correction_{} {}
 
 
 i32 History::quiet_bonus(i32 depth) const {
@@ -123,24 +124,40 @@ i32 History::get_noisyscore(chess::Move move, chess::Piece captured) const {
 }
 
 
-void History::update_corrections(const chess::Board& board, i32 depth, i32 score, i32 static_eval) {
+void History::update_corrections(
+    const Position<true>& position, i32 depth, i32 score, i32 static_eval
+) {
     const auto bonus = clamp(
         (score - static_eval) * depth / CORRHIST_BONUS_DEPTH_DIV,
         -CORRHIST_BONUS_MAX,
         CORRHIST_BONUS_MAX
     );
+
+    const auto& board = position.board();
+    const auto curr = position.prev_move(1);
+    const auto prev1 = position.prev_move(2);
+
     pawn_corr_entry(board).update(bonus);
     major_corr_entry(board).update(bonus);
     nonpawn_corr_entry(board, chess::Color::WHITE).update(bonus);
     nonpawn_corr_entry(board, chess::Color::BLACK).update(bonus);
+    if (prev1.moving != chess::Piece::NONE)
+        cont_corr_entry(curr.move, curr.moving, prev1).update(bonus);
 }
 
-i32 History::correct(const chess::Board& board, i32 score) const {
+i32 History::correct(const Position<true>& position, i32 score) const {
+    const auto& board = position.board();
+    const auto curr = position.prev_move(1);
+    const auto prev1 = position.prev_move(2);
+
     i32 correction = 0;
     correction += pawn_corr_entry(board) * PAWN_CORRHIST_WEIGHT;
     correction += major_corr_entry(board) * MAJOR_CORRHIST_WEIGHT;
     correction += nonpawn_corr_entry(board, chess::Color::WHITE) * NONPAWN_CORRHIST_WEIGHT;
     correction += nonpawn_corr_entry(board, chess::Color::BLACK) * NONPAWN_CORRHIST_WEIGHT;
+    correction += (prev1.moving != chess::Piece::NONE)
+                      ? cont_corr_entry(curr.move, curr.moving, prev1) * CONT1_CORRHIST_WEIGHT
+                      : 0;
     correction /= CORRHIST_MAX;
 
     return clamp(score + correction, -MATE_SCORE + 1, MATE_SCORE - 1);
@@ -154,6 +171,7 @@ void History::clear() {
     memset(pawn_correction_, 0, sizeof(pawn_correction_));
     memset(major_correction_, 0, sizeof(major_correction_));
     memset(nonpawn_correction_, 0, sizeof(nonpawn_correction_));
+    memset(cont_correction_, 0, sizeof(cont_correction_));
 }
 
 
@@ -214,4 +232,21 @@ const CorrectionEntry& History::nonpawn_corr_entry(
 }
 CorrectionEntry& History::nonpawn_corr_entry(const chess::Board& board, chess::Color color) {
     return nonpawn_correction_[board.stm()][color][board.nonpawn_hash(color) % CORRHIST_SIZE];
+}
+
+const CorrectionEntry& History::cont_corr_entry(
+    chess::Move move, chess::Piece moving, chess::PieceMove prev_move
+) const {
+    assert(prev_move.move != chess::Move::NO_MOVE);
+    assert(prev_move.move != chess::Move::NULL_MOVE);
+    assert(prev_move.moving != chess::Piece::NONE);
+    return cont_correction_[prev_move.moving][prev_move.move.to()][moving][move.to()];
+}
+CorrectionEntry& History::cont_corr_entry(
+    chess::Move move, chess::Piece moving, chess::PieceMove prev_move
+) {
+    assert(prev_move.move != chess::Move::NO_MOVE);
+    assert(prev_move.move != chess::Move::NULL_MOVE);
+    assert(prev_move.moving != chess::Piece::NONE);
+    return cont_correction_[prev_move.moving][prev_move.move.to()][moving][move.to()];
 }

--- a/src/Raphael/History.h
+++ b/src/Raphael/History.h
@@ -46,6 +46,7 @@ private:
     CorrectionEntry pawn_correction_[2][CORRHIST_SIZE];        // [stm][pawn_hash idx]
     CorrectionEntry major_correction_[2][CORRHIST_SIZE];       // [stm][major_hash idx]
     CorrectionEntry nonpawn_correction_[2][2][CORRHIST_SIZE];  // [stm][color][nonpawn_hash idx]
+    CorrectionEntry cont_correction_[12][64][12][64];          // [prev from][prev to][from][to]
 
 public:
     /** Initializes all the history tables with zeros */
@@ -125,20 +126,20 @@ public:
 
     /** Updates the correction histories
      *
-     * \param board current board
+     * \param position current position
      * \param depth current depth
      * \param score current score
      * \param static_eval current static eval
      */
-    void update_corrections(const chess::Board& board, i32 depth, i32 score, i32 static_eval);
+    void update_corrections(const Position<true>& position, i32 depth, i32 score, i32 static_eval);
 
     /** Returns the corrected score
      *
-     * \param board current board
+     * \param position current position
      * \param score score to correct
      * \returns the corrected score
      */
-    i32 correct(const chess::Board& board, i32 score) const;
+    i32 correct(const Position<true>& position, i32 score) const;
 
 
     /** Zeros out all the histories */
@@ -199,5 +200,19 @@ private:
      */
     const CorrectionEntry& nonpawn_corr_entry(const chess::Board& board, chess::Color color) const;
     CorrectionEntry& nonpawn_corr_entry(const chess::Board& board, chess::Color color);
+
+    /** Returns a reference to the continuation correction history entry
+     *
+     * \param move current move
+     * \param moving current moving piece
+     * \param prev_move previous move and moving piece
+     * \returns continuation history entry
+     */
+    const CorrectionEntry& cont_corr_entry(
+        chess::Move move, chess::Piece moving, chess::PieceMove prev_move
+    ) const;
+    CorrectionEntry& cont_corr_entry(
+        chess::Move move, chess::Piece moving, chess::PieceMove prev_move
+    );
 };
 }  // namespace raphael

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -206,7 +206,7 @@ void Raphael::ponder(atomic<bool>& halt) {
 
 i32 Raphael::static_eval(bool corrected) {
     const auto raw_score = position_.evaluate(!params_.datagen);
-    return (corrected) ? history_.correct(position_.board(), raw_score) : raw_score;
+    return (corrected) ? history_.correct(position_, raw_score) : raw_score;
 }
 
 
@@ -314,7 +314,7 @@ i32 Raphael::negamax(
             else
                 raw_static_eval = position_.evaluate(!params_.datagen);
 
-            ss->static_eval = history_.correct(board, raw_static_eval);
+            ss->static_eval = history_.correct(position_, raw_static_eval);
         }
     }
     const bool improving = !in_check && ss->static_eval > (ss - 2)->static_eval;
@@ -547,7 +547,7 @@ i32 Raphael::negamax(
         if (!in_check && (bestmove == chess::Move::NO_MOVE || board.is_quiet(bestmove))
             && (ttflag == tt_.EXACT || (ttflag == tt_.LOWER && bestscore > ss->static_eval)
                 || (ttflag == tt_.UPPER && bestscore < ss->static_eval)))
-            history_.update_corrections(board, depth, bestscore, ss->static_eval);
+            history_.update_corrections(position_, depth, bestscore, ss->static_eval);
         tt_.set(ttkey, bestscore, raw_static_eval, bestmove, depth, ttflag, ply);
     }
 
@@ -566,7 +566,7 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
     // max ply
     const bool in_check = board.in_check();
     if (ply >= MAX_DEPTH - 1)
-        return (in_check) ? 0 : history_.correct(board, position_.evaluate(!params_.datagen));
+        return (in_check) ? 0 : history_.correct(position_, position_.evaluate(!params_.datagen));
 
     // probe transposition table
     const auto ttkey = board.hash();
@@ -595,7 +595,7 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
         else
             raw_static_eval = position_.evaluate(!params_.datagen);
 
-        static_eval = history_.correct(board, raw_static_eval);
+        static_eval = history_.correct(position_, raw_static_eval);
 
         if (static_eval >= beta) return static_eval;
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -305,6 +305,7 @@ static constexpr i32 CORRHIST_BONUS_MAX = 256;
 Tunable(PAWN_CORRHIST_WEIGHT, 56, 32, 384, true);
 Tunable(MAJOR_CORRHIST_WEIGHT, 48, 32, 384, true);
 Tunable(NONPAWN_CORRHIST_WEIGHT, 48, 32, 384, true);
+Tunable(CONT1_CORRHIST_WEIGHT, 64, 32, 384, true);
 
 // eval scaling
 Tunable(MAT_SCALE_BASE, 25100, 20000, 30000, true);


### PR DESCRIPTION
```
Elo   | 7.13 +- 4.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6284 W: 1517 L: 1388 D: 3379
Penta | [13, 697, 1598, 816, 18]
```
https://rmeguro.pythonanywhere.com/test/284/
bench: 6901466