### PR TITLE
feat: halfmove eval scaling

### DIFF
--- a/src/Raphael/History.cpp
+++ b/src/Raphael/History.cpp
@@ -160,7 +160,7 @@ i32 History::correct(const Position<true>& position, i32 score) const {
                       : 0;
     correction /= CORRHIST_MAX;
 
-    return clamp(score + correction, -MATE_SCORE + 1, MATE_SCORE - 1);
+    return score + correction;
 }
 
 

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -5,6 +5,7 @@
 #include <Raphael/movepick.h>
 #include <Raphael/utils.h>
 
+#include <algorithm>
 #include <climits>
 #include <cmath>
 #include <future>
@@ -12,6 +13,7 @@
 
 using namespace raphael;
 using std::atomic;
+using std::clamp;
 using std::copy;
 using std::cout;
 using std::flush;
@@ -206,7 +208,7 @@ void Raphael::ponder(atomic<bool>& halt) {
 
 i32 Raphael::static_eval(bool corrected) {
     const auto raw_score = position_.evaluate(!params_.datagen);
-    return (corrected) ? history_.correct(position_, raw_score) : raw_score;
+    return (corrected) ? adjust_score(raw_score) : raw_score;
 }
 
 
@@ -240,6 +242,19 @@ string Raphael::get_pv_line(const PVList& pv) const {
     for (i32 i = 0; i < pv.length; i++)
         pvline += chess::uci::from_move(pv.moves[i], chess960) + " ";
     return pvline;
+}
+
+
+i32 Raphael::adjust_score(i32 raw_static_eval) const {
+    const auto& board = position_.board();
+
+    // halfmove scaling
+    if (!params_.datagen) raw_static_eval = raw_static_eval * (200 - board.halfmoves()) / 200;
+
+    // corrhist
+    raw_static_eval = history_.correct(position_, raw_static_eval);
+
+    return clamp(raw_static_eval, -MATE_SCORE + 1, MATE_SCORE - 1);
 }
 
 
@@ -314,7 +329,7 @@ i32 Raphael::negamax(
             else
                 raw_static_eval = position_.evaluate(!params_.datagen);
 
-            ss->static_eval = history_.correct(position_, raw_static_eval);
+            ss->static_eval = adjust_score(raw_static_eval);
         }
     }
     const bool improving = !in_check && ss->static_eval > (ss - 2)->static_eval;
@@ -566,7 +581,7 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
     // max ply
     const bool in_check = board.in_check();
     if (ply >= MAX_DEPTH - 1)
-        return (in_check) ? 0 : history_.correct(position_, position_.evaluate(!params_.datagen));
+        return (in_check) ? 0 : adjust_score(position_.evaluate(!params_.datagen));
 
     // probe transposition table
     const auto ttkey = board.hash();
@@ -595,7 +610,7 @@ i32 Raphael::quiescence(const i32 ply, const i32 mvidx, i32 alpha, i32 beta, ato
         else
             raw_static_eval = position_.evaluate(!params_.datagen);
 
-        static_eval = history_.correct(position_, raw_static_eval);
+        static_eval = adjust_score(raw_static_eval);
 
         if (static_eval >= beta) return static_eval;
 

--- a/src/Raphael/Raphael.h
+++ b/src/Raphael/Raphael.h
@@ -173,6 +173,14 @@ private:
     std::string get_pv_line(const PVList& pv) const;
 
 
+    /** Adjusts the raw static eval using scaling and corrhists
+     *
+     * \param raw_static_eval raw eval to adjust
+     * \returns the adjusted eval
+     */
+    i32 adjust_score(i32 raw_static_eval) const;
+
+
     /** Recursively searches for the best move and score of the current position assuming optimal
      * play by both us and the opponent
      *

--- a/src/Raphael/position.h
+++ b/src/Raphael/position.h
@@ -104,6 +104,7 @@ public:
     {
         i32 static_eval = net_.evaluate(current_);
         if (do_scaling) {
+            // material scaling
             const i32 material_scale
                 = MAT_SCALE_BASE + current_.occ(chess::PieceType::PAWN).count() * MAT_SCALE_PAWN
                   + current_.occ(chess::PieceType::KNIGHT).count() * MAT_SCALE_KNIGHT
@@ -111,6 +112,9 @@ public:
                   + current_.occ(chess::PieceType::ROOK).count() * MAT_SCALE_ROOK
                   + current_.occ(chess::PieceType::QUEEN).count() * MAT_SCALE_QUEEN;
             static_eval = static_eval * material_scale / 32768;
+
+            // halfmove scaling
+            static_eval = static_eval * (200 - current_.halfmoves()) / 200;
         }
         return std::clamp(static_eval, -MATE_SCORE + 1, MATE_SCORE - 1);
     }

--- a/src/Raphael/position.h
+++ b/src/Raphael/position.h
@@ -2,7 +2,6 @@
 #include <Raphael/nnue.h>
 #include <Raphael/tunable.h>
 
-#include <algorithm>
 #include <cstddef>
 #include <type_traits>
 
@@ -112,11 +111,8 @@ public:
                   + current_.occ(chess::PieceType::ROOK).count() * MAT_SCALE_ROOK
                   + current_.occ(chess::PieceType::QUEEN).count() * MAT_SCALE_QUEEN;
             static_eval = static_eval * material_scale / 32768;
-
-            // halfmove scaling
-            static_eval = static_eval * (200 - current_.halfmoves()) / 200;
         }
-        return std::clamp(static_eval, -MATE_SCORE + 1, MATE_SCORE - 1);
+        return static_eval;
     }
 
 


### PR DESCRIPTION
failed stc:
```
Elo   | 0.40 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 5.00]
Games | N: 32024 W: 7349 L: 7312 D: 17363
Penta | [85, 3818, 8150, 3893, 66]
```
https://rmeguro.pythonanywhere.com/test/281/

passed ltc
```
Elo   | 2.90 +- 2.30 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21084 W: 4844 L: 4668 D: 11572
Penta | [3, 2417, 5540, 2565, 17]
```
https://rmeguro.pythonanywhere.com/test/282/
bench: 6074601