### PR TITLE
feat: movepick direct check bonus

### DIFF
--- a/src/Raphael/movepick.cpp
+++ b/src/Raphael/movepick.cpp
@@ -250,9 +250,12 @@ void MoveGenerator::score_noisies() {
 }
 
 void MoveGenerator::score_quiets() {
+    const auto& board = position_->board();
+
     for (usize i = idx_; i < end_; i++) {
         auto& smove = (*movelist_)[i];
         smove.score = history_->get_quietscore(smove.move, *position_);
+        if (board.gives_direct_check(smove.move)) smove.score += DIRECT_CHECK_BONUS;
     }
 }
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -278,6 +278,8 @@ static constexpr i32 CAPTHIST_DIV = 8;
 Tunable(GOOD_NOISY_SEE_BASE, -22, -128, 128, true);
 Tunable(GOOD_NOISY_SEE_MUL, 16, 16, 128, false);
 
+Tunable(DIRECT_CHECK_BONUS, 4096, 1024, 8192, true);
+
 Tunable(HISTORY_BONUS_DEPTH_MUL, 103, 32, 384, true);
 Tunable(HISTORY_BONUS_BASE, 96, 32, 384, true);
 Tunable(HISTORY_BONUS_MAX, 1909, 1024, 4096, true);


### PR DESCRIPTION
I believe idea by @JonathanHallstrom 

stc
```
Elo   | 6.32 +- 4.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7142 W: 1689 L: 1559 D: 3894
Penta | [6, 828, 1784, 936, 17]
```
https://rmeguro.pythonanywhere.com/test/290/

ltc
```
Elo   | 2.80 +- 2.24 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 22312 W: 5247 L: 5067 D: 11998
Penta | [13, 2543, 5863, 2725, 12]
```
https://rmeguro.pythonanywhere.com/test/291/

bench: 7069207