### PR TITLE
feat: hindsight extensions

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -450,6 +450,11 @@ i32 Raphael::negamax(
 
     // pre-moveloop pruning
     if (!is_PV && !in_check && !ss->excluded) {
+        // hindsight extension
+        if ((ss - 1)->reductions >= HINDSIGHT_MIN_RED && (ss - 1)->static_eval != NONE_SCORE
+            && ss->static_eval <= -(ss - 1)->static_eval)
+            depth++;
+
         // reverse futility pruning
         const i32 rfp_margin = RFP_MARGIN_DEPTH_MUL * depth - RFP_MARGIN_IMPROVING * improving;
         if (depth <= RFP_MAX_DEPTH && ss->static_eval - rfp_margin >= beta) return ss->static_eval;
@@ -587,11 +592,14 @@ i32 Raphael::negamax(
             red_factor -= improving * LMR_IMPROVING;
             red_factor -= gives_check * LMR_CHECK;
             red_factor -= hist * 128 / ((is_quiet) ? LMR_QUIET_HIST_DIV : LMR_NOISY_HIST_DIV);
+            red_factor /= 128;
 
-            const i32 red_depth = min(max(new_depth - red_factor / 128, 1), new_depth);
+            ss->reductions = red_factor;
+            const i32 red_depth = min(max(new_depth - red_factor, 1), new_depth);
             score = -negamax<false>(
                 tdata, red_depth, ply + 1, -alpha - 1, -alpha, true, ss + 1, mv + 1
             );
+            ss->reductions = 0;
 
             if (score > alpha && red_depth < new_depth)
                 score = -negamax<false>(

--- a/src/Raphael/Raphael.h
+++ b/src/Raphael/Raphael.h
@@ -65,6 +65,7 @@ private:
         chess::Move move = chess::Move::NO_MOVE;
         chess::Move killer = chess::Move::NO_MOVE;
         chess::Move excluded = chess::Move::NO_MOVE;
+        i16 reductions = 0;
     };
 
     struct MoveStack {

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -214,6 +214,7 @@ Tunable(TT_VALUE_AGE_WEIGHT, 1, 0, 4, false);
 
 // negamax
 Tunable(IIR_MIN_DEPTH, 3, 3, 6, false);
+Tunable(HINDSIGHT_MIN_RED, 3, 3, 6, false);
 
 Tunable(RFP_MAX_DEPTH, 6, 1, 10, false);
 Tunable(RFP_MARGIN_DEPTH_MUL, 65, 16, 128, true);


### PR DESCRIPTION
```
Elo   | 2.98 +- 2.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21248 W: 4895 L: 4713 D: 11640
Penta | [45, 2426, 5498, 2612, 43]
```
https://rmeguro.pythonanywhere.com/test/340/
bench: 6972639