### PR TITLE
feat: dodeepershallower

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -583,7 +583,7 @@ i32 Raphael::negamax(
 
         // principle variation search
         i32 score = INT32_MIN;
-        const i32 new_depth = depth - 1 + extension;
+        i32 new_depth = depth - 1 + extension;
         if (depth >= LMR_MIN_DEPTH && move_searched > LMR_FROMMOVE) {
             // late move reduction
             i32 red_factor = LMR_TABLE[is_quiet][depth][move_searched];
@@ -601,10 +601,17 @@ i32 Raphael::negamax(
             );
             ss->reductions = 0;
 
-            if (score > alpha && red_depth < new_depth)
+            if (score > alpha && red_depth < new_depth) {
+                const bool do_deeper
+                    = score > bestscore + DO_DEEPER_BASE + DO_DEEPER_DEPTH_MUL * new_depth;
+                const bool do_shallower
+                    = score < bestscore + DO_SHALLOWER_BASE + DO_SHALLOWER_DEPTH_MUL * new_depth;
+                new_depth += do_deeper - do_shallower;
+
                 score = -negamax<false>(
                     tdata, new_depth, ply + 1, -alpha - 1, -alpha, !cutnode, ss + 1, mv + 1
                 );
+            }
         } else if (!is_PV || move_searched > 1)
             score = -negamax<false>(
                 tdata, new_depth, ply + 1, -alpha - 1, -alpha, !cutnode, ss + 1, mv + 1

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -259,6 +259,10 @@ Tunable(LMR_IMPROVING, 115, 32, 384, true);
 Tunable(LMR_CHECK, 163, 32, 384, true);
 Tunable(LMR_QUIET_HIST_DIV, 11863, 4096, 16384, true);
 Tunable(LMR_NOISY_HIST_DIV, 12298, 4096, 16384, true);
+Tunable(DO_DEEPER_BASE, 40, 0, 128, false);
+Tunable(DO_DEEPER_DEPTH_MUL, 6, 1, 12, false);
+Tunable(DO_SHALLOWER_BASE, 0, 0, 128, false);
+Tunable(DO_SHALLOWER_DEPTH_MUL, 1, 1, 12, false);
 
 // quiescence
 Tunable(QS_MAX_MOVES, 3, 1, 5, false);


### PR DESCRIPTION
Based on https://github.com/Ciekce/Stormphrax/pull/160
```
Elo   | 2.49 +- 2.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 28508 W: 6509 L: 6305 D: 15694
Penta | [59, 3248, 7445, 3434, 68]
```
https://rmeguro.pythonanywhere.com/test/341/
bench: 6849591