### PR TITLE
feat: nmp verification search

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -467,7 +467,7 @@ i32 Raphael::negamax(
         }
 
         // null move pruning
-        if (depth >= NMP_MIN_DEPTH && ss->static_eval >= beta
+        if (depth >= NMP_MIN_DEPTH && ply >= tdata.min_nmp_ply && ss->static_eval >= beta
             && (ss - 1)->move != chess::Move::NULL_MOVE
             && !(ttentry.flag == tt_.UPPER && ttentry.score < beta)
             && !board.is_kingpawn(board.stm())) {
@@ -478,15 +478,27 @@ i32 Raphael::negamax(
             i32 red_factor = NMP_RED_BASE;
             red_factor += depth * NMP_RED_DEPTH_MUL;
             red_factor += min<i32>((ss->static_eval - beta) * NMP_RED_EVAL_MUL, NMP_RED_EVAL_MAX);
+            red_factor /= 128;
 
-            const i32 red_depth = depth - red_factor / 128;
+            const i32 red_depth = depth - red_factor;
             const i32 score = -negamax<false>(
                 tdata, red_depth, ply + 1, -beta, -beta + 1, !cutnode, ss + 1, mv
             );
 
             position.unmake_nullmove();
 
-            if (score >= beta) return (utils::is_win(score)) ? beta : score;
+            if (score >= beta) {
+                if (depth < NMP_VERIF_MIN_DEPTH || tdata.min_nmp_ply > 0)
+                    return (utils::is_win(score)) ? beta : score;
+
+                // verification search (disable nmp for a fraction of the depths)
+                tdata.min_nmp_ply = ply + red_depth * NMP_VERIF_DEPTH_FACTOR / 128;
+                const i32 verif_score
+                    = negamax<false>(tdata, red_depth, ply, beta - 1, beta, true, ss, mv + 1);
+                tdata.min_nmp_ply = 0;
+
+                if (verif_score >= beta) return verif_score;
+            }
         }
     }
 

--- a/src/Raphael/Raphael.h
+++ b/src/Raphael/Raphael.h
@@ -80,6 +80,7 @@ private:
 
         Position<true> position_;
         History history;
+        i32 min_nmp_ply;
         i32 thread_id;
     };
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -229,6 +229,8 @@ Tunable(NMP_RED_BASE, 531, 256, 1024, true);
 Tunable(NMP_RED_DEPTH_MUL, 25, 8, 64, false);
 Tunable(NMP_RED_EVAL_MUL, 82, 16, 128, false);
 Tunable(NMP_RED_EVAL_MAX, 384, 128, 512, false);
+Tunable(NMP_VERIF_MIN_DEPTH, 15, 10, 20, false);
+Tunable(NMP_VERIF_DEPTH_FACTOR, 96, 32, 128, false);
 
 inline MultiArray<i32, 2, 256> LMP_TABLE;  // lmp moves threshold[improving][depth]
 TunableCallback(LMP_THRESH_BASE, 3, 1, 12, update_lmp_table, false);


### PR DESCRIPTION
based on https://github.com/Ciekce/Stormphrax/pull/205
```
Elo   | -0.72 +- 1.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 66686 W: 15113 L: 15251 D: 36322
Penta | [117, 7787, 17696, 7603, 140]
```
https://rmeguro.pythonanywhere.com/test/343/
bench: 6521312