### PR TITLE
feat: store static eval in pad space of cluster

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -441,8 +441,10 @@ i32 Raphael::negamax(
         } else {
             if (tthit && ttentry.static_eval != NONE_SCORE)
                 raw_static_eval = ttentry.static_eval;
-            else
+            else if (!tt_.get_static_eval(ttkey, raw_static_eval)) {
                 raw_static_eval = position.evaluate(!params_.datagen);
+                tt_.set_static_eval(ttkey, raw_static_eval);
+            }
 
             ss->static_eval = adjust_score(tdata, raw_static_eval);
         }
@@ -756,8 +758,10 @@ i32 Raphael::quiescence(ThreadData& tdata, const i32 ply, i32 alpha, i32 beta, M
     } else {
         if (tthit && ttentry.static_eval != NONE_SCORE)
             raw_static_eval = ttentry.static_eval;
-        else
+        else if (!tt_.get_static_eval(ttkey, raw_static_eval)) {
             raw_static_eval = position.evaluate(!params_.datagen);
+            tt_.set_static_eval(ttkey, raw_static_eval);
+        }
 
         static_eval = adjust_score(tdata, raw_static_eval);
 

--- a/src/Raphael/Transposition.cpp
+++ b/src/Raphael/Transposition.cpp
@@ -53,7 +53,6 @@ void TranspositionTable::resize(i32 size_mb) {
 }
 
 bool TranspositionTable::get(ProbedEntry& ttentry, u64 key, i32 ply) const {
-    // get
     const auto& cluster = table_[index(key)];
     const auto packed_key = static_cast<u16>(key);
 
@@ -133,6 +132,25 @@ void TranspositionTable::set(
     entry->static_eval = static_cast<i16>(static_eval);
     entry->fdepth = static_cast<u16>(fdepth);
     entry->set_age_flag(age_, flag);
+}
+
+bool TranspositionTable::get_static_eval(u64 key, i32& static_eval) const {
+    const auto& cluster = table_[index(key)];
+    const auto packed_key = static_cast<u16>(key);
+
+    if (cluster.key == packed_key) {
+        static_eval = cluster.static_eval;
+        return true;
+    }
+    return false;
+}
+
+void TranspositionTable::set_static_eval(u64 key, i32 static_eval) {
+    auto& cluster = table_[index(key)];
+    const auto packed_key = static_cast<u16>(key);
+
+    cluster.key = packed_key;
+    cluster.static_eval = static_eval;
 }
 
 void TranspositionTable::clear() {

--- a/src/Raphael/Transposition.h
+++ b/src/Raphael/Transposition.h
@@ -44,7 +44,8 @@ public:
 
     struct alignas(64) Cluster {
         Entry entries[ENTRIES_PER_CLUSTER];
-        u32 pad;
+        u16 key;
+        i16 static_eval;
     };
     static constexpr usize CLUSTER_SIZE = sizeof(Cluster);
     static_assert(CLUSTER_SIZE == 64);
@@ -112,6 +113,21 @@ public:
      * \param ply current distance from root
      */
     void set(u64 key, i32 score, i32 static_eval, chess::Move move, i32 fdepth, Flag flag, i32 ply);
+
+    /** Retrieves the static eval for a given key
+     *
+     * \param key zobrist hash of position
+     * \param static_eval variable to put static eval into
+     * \returns whether the static eval for this key was found
+     */
+    bool get_static_eval(u64 key, i32& static_eval) const;
+
+    /**  Stores the static eval for a given key
+     *
+     * \param key zobrist hash of position
+     * \param static_eval static eval of position
+     */
+    void set_static_eval(u64 key, i32 static_eval);
 
     /** Clears the table */
     void clear();


### PR DESCRIPTION
stc:
```
Elo   | 8.42 +- 4.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5036 W: 1202 L: 1080 D: 2754
Penta | [12, 544, 1282, 670, 10]
```
https://rmeguro.pythonanywhere.com/test/385/

ltc:
```
Elo   | 5.31 +- 3.62 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8308 W: 1890 L: 1763 D: 4655
Penta | [1, 908, 2209, 1035, 1]
```
https://rmeguro.pythonanywhere.com/test/386/

bench: 7568202