### PR TITLE
feat: aspiration fail high reduction

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -317,6 +317,7 @@ Raphael::MoveScore Raphael::iterative_deepen(ThreadData& tdata) {
         i32 delta = ASP_INIT_SIZE;
         i32 alpha = -INF_SCORE;
         i32 beta = INF_SCORE;
+        i32 asp_fred = 0;
 
         if (depth >= ASP_MIN_DEPTH) {
             alpha = max(score - delta, -INF_SCORE);
@@ -326,14 +327,17 @@ Raphael::MoveScore Raphael::iterative_deepen(ThreadData& tdata) {
         // search until score lies between alpha and beta
         i32 iterscore;
         while (!stop_.load(memory_order_relaxed)) {
-            iterscore = negamax<true>(tdata, depth * DEPTH_SCALE, 0, alpha, beta, false, ss, mv);
+            const i32 asp_fdepth = max(depth * DEPTH_SCALE - asp_fred, DEPTH_SCALE);
+            iterscore = negamax<true>(tdata, asp_fdepth, 0, alpha, beta, false, ss, mv);
 
             if (iterscore <= alpha) {
                 beta = (alpha + beta) / 2;
                 alpha = max(score - delta, -INF_SCORE);
-            } else if (iterscore >= beta)
+                asp_fred = 0;
+            } else if (iterscore >= beta) {
                 beta = min(score + delta, INF_SCORE);
-            else
+                asp_fred = min(asp_fred + ASP_RED, ASP_MAX_RED);
+            } else
                 break;
 
             delta += delta * ASP_WIDENING_FACTOR / 128;

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -209,6 +209,8 @@ Tunable(NODE_TM_MUL, 150, 100, 200, false);
 Tunable(ASP_MIN_DEPTH, 3, 2, 5, false);
 Tunable(ASP_INIT_SIZE, 36, 5, 100, true);
 Tunable(ASP_WIDENING_FACTOR, 96, 16, 192, true);
+Tunable(ASP_RED, 128, 64, 256, true);
+Tunable(ASP_MAX_RED, 384, 128, 640, true);
 
 Tunable(TT_REPL_DEPTH_MARGIN, 512, 0, 1024, false);
 Tunable(TT_VALUE_DEPTH_WEIGHT, 128, 0, 512, false);


### PR DESCRIPTION
```
Elo   | 1.58 +- 1.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 4.00]
Games | N: 79606 W: 17832 L: 17469 D: 44305
Penta | [178, 9295, 20536, 9574, 220]
```
https://rmeguro.pythonanywhere.com/test/394/
bench: 6356005