### PR TITLE
feat: increase se min depth if ttpv

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -578,8 +578,9 @@ i32 Raphael::negamax(
 
         // extensions
         i32 fext = 0;
-        if (!is_root && fdepth >= SE_MIN_DEPTH && move == ttmove && !ss->excluded
-            && ttentry.fdepth >= fdepth - SE_MIN_TT_DEPTH && ttentry.flag != tt_.UPPER) {
+        if (!is_root && fdepth >= SE_MIN_DEPTH + ss->ttpv * SE_MIN_DEPTH_TTPV && move == ttmove
+            && !ss->excluded && ttentry.fdepth >= fdepth - SE_MIN_TT_DEPTH
+            && ttentry.flag != tt_.UPPER) {
             const i32 s_beta = max(
                 ttentry.score
                     - SE_MARGIN_DEPTH_MUL * ((ttentry.flag == tt_.EXACT) ? 1 : 2) * fdepth

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -251,7 +251,8 @@ Tunable(FP_MARGIN_BASE, 101, 32, 384, true);
 Tunable(SEE_QUIET_DEPTH_MUL, -36, -128, -16, true);
 Tunable(SEE_NOISY_DEPTH_MUL, -108, -256, -32, true);
 
-Tunable(SE_MIN_DEPTH, 867, 768, 1536, true);
+Tunable(SE_MIN_DEPTH, 739, 512, 1536, true);
+Tunable(SE_MIN_DEPTH_TTPV, 128, 32, 384, true);
 Tunable(SE_MIN_TT_DEPTH, 384, 384, 768, false);
 Tunable(SE_MARGIN_DEPTH_MUL, 128, 64, 512, false);
 Tunable(DE_MARGIN, 30, 8, 64, false);


### PR DESCRIPTION
```
Elo   | 5.92 +- 3.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7928 W: 1849 L: 1714 D: 4365
Penta | [18, 896, 2008, 1017, 25]
```
https://rmeguro.pythonanywhere.com/test/420/
bench: 6104956