### PR TITLE
feat: mix history into fp margin

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -569,7 +569,8 @@ i32 Raphael::negamax(
 
                 // futility pruning
                 const i32 futility = ss->static_eval + FP_MARGIN_BASE
-                                     + FP_MARGIN_DEPTH_MUL * lmr_fdepth / DEPTH_SCALE;
+                                     + FP_MARGIN_DEPTH_MUL * lmr_fdepth / DEPTH_SCALE
+                                     + FP_MARGIN_HIST_MUL * hist / HISTORY_MAX;
                 if (!in_check && lmr_fdepth <= FP_MAX_DEPTH && futility <= alpha
                     && !board.gives_direct_check(move)) {
                     generator.skip_quiets();

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -247,7 +247,7 @@ TunableCallback(LMP_THRESH_BASE, 3, 1, 12, update_lmp_table, false);
 Tunable(FP_MAX_DEPTH, 892, 512, 1536, true);
 Tunable(FP_MARGIN_DEPTH_MUL, 66, 32, 384, true);
 Tunable(FP_MARGIN_BASE, 101, 32, 384, true);
-Tunable(FP_MARGIN_HIST_MUL, 256, 32, 384, true);
+Tunable(FP_MARGIN_HIST_MUL, 200, 32, 384, true);
 
 Tunable(SEE_QUIET_DEPTH_MUL, -36, -128, -16, true);
 Tunable(SEE_NOISY_DEPTH_MUL, -108, -256, -32, true);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -247,7 +247,7 @@ TunableCallback(LMP_THRESH_BASE, 3, 1, 12, update_lmp_table, false);
 Tunable(FP_MAX_DEPTH, 892, 512, 1536, true);
 Tunable(FP_MARGIN_DEPTH_MUL, 66, 32, 384, true);
 Tunable(FP_MARGIN_BASE, 101, 32, 384, true);
-Tunable(FP_MARGIN_HIST_MUL, 200, 32, 384, true);
+Tunable(FP_MARGIN_HIST_MUL, 344, 64, 512, true);
 
 Tunable(SEE_QUIET_DEPTH_MUL, -36, -128, -16, true);
 Tunable(SEE_NOISY_DEPTH_MUL, -108, -256, -32, true);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -247,6 +247,7 @@ TunableCallback(LMP_THRESH_BASE, 3, 1, 12, update_lmp_table, false);
 Tunable(FP_MAX_DEPTH, 892, 512, 1536, true);
 Tunable(FP_MARGIN_DEPTH_MUL, 66, 32, 384, true);
 Tunable(FP_MARGIN_BASE, 101, 32, 384, true);
+Tunable(FP_MARGIN_HIST_MUL, 256, 32, 384, true);
 
 Tunable(SEE_QUIET_DEPTH_MUL, -36, -128, -16, true);
 Tunable(SEE_NOISY_DEPTH_MUL, -108, -256, -32, true);


### PR DESCRIPTION
```
Elo   | 3.29 +- 2.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 17646 W: 4094 L: 3927 D: 9625
Penta | [35, 2037, 4529, 2170, 52]
```
https://rmeguro.pythonanywhere.com/test/425/
bench: 6272769