### PR TITLE
feat: low depth singular extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ To see all supported commands, run `uci.exe help`
     - [x] Triple extensions                 (`v4.0+`)
     - [x] Negative extensions               (`v3.0+`)
     - [x] Cutnode negative extensions       (`v3.1+`)
-    - [ ] Low depth singular extensions
+    - [x] Low depth singular extensions     (`v4.0+`)
     - [x] Hindsight extensions              (`v4.0+`)
   - [x] Reductions                          (`v1.5+`)
     - [x] Late move reductions              (`v1.5+`)

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -591,34 +591,40 @@ i32 Raphael::negamax(
 
         // extensions
         i32 fext = 0;
-        if (!is_root && fdepth >= SE_MIN_DEPTH + ss->ttpv * SE_MIN_DEPTH_TTPV && move == ttmove
-            && !ss->excluded && ttentry.fdepth >= fdepth - SE_MIN_TT_DEPTH
-            && ttentry.flag != tt_.UPPER)
-        {
-            const i32 s_beta = max(
-                ttentry.score
-                    - SE_MARGIN_DEPTH_MUL * ((ttentry.flag == tt_.EXACT) ? 1 : 2) * fdepth
-                          / (DEPTH_SCALE * 128),
-                -MATE_SCORE + 1
-            );
-            const i32 s_fdepth = (fdepth - DEPTH_SCALE) / 2;
+        if (!is_root && move == ttmove && !ss->excluded) {
+            if (fdepth >= SE_MIN_DEPTH + ss->ttpv * SE_MIN_DEPTH_TTPV
+                && ttentry.fdepth >= fdepth - SE_MIN_TT_DEPTH && ttentry.flag != tt_.UPPER)
+            {
+                const i32 s_beta = max(
+                    ttentry.score
+                        - SE_MARGIN_DEPTH_MUL * ((ttentry.flag == tt_.EXACT) ? 1 : 2) * fdepth
+                              / (DEPTH_SCALE * 128),
+                    -MATE_SCORE + 1
+                );
+                const i32 s_fdepth = (fdepth - DEPTH_SCALE) / 2;
 
-            ss->excluded = move;
-            const i32 score
-                = negamax<false>(tdata, s_fdepth, ply, s_beta - 1, s_beta, cutnode, ss, mv + 1);
-            ss->excluded = chess::Move::NO_MOVE;
+                ss->excluded = move;
+                const i32 score
+                    = negamax<false>(tdata, s_fdepth, ply, s_beta - 1, s_beta, cutnode, ss, mv + 1);
+                ss->excluded = chess::Move::NO_MOVE;
 
-            if (score < s_beta) {
-                if (!is_PV && score + DE_MARGIN < s_beta)
-                    fext = SE_EXT + DE_EXT + TE_EXT * (is_quiet && score + TE_MARGIN < s_beta);
-                else
-                    fext = SE_EXT;  // singular extensions
-            } else if (s_beta >= beta)
-                return s_beta;  // multicut
-            else if (cutnode)
-                fext = -CUTNODE_NE_RED;  // cutnode negative extensions
-            else if (ttentry.score >= beta)
-                fext = -NE_RED;  // negative extensions
+                if (score < s_beta) {
+                    if (!is_PV && score + DE_MARGIN < s_beta)
+                        fext = SE_EXT + DE_EXT + TE_EXT * (is_quiet && score + TE_MARGIN < s_beta);
+                    else
+                        fext = SE_EXT;  // singular extensions
+                } else if (s_beta >= beta)
+                    return s_beta;  // multicut
+                else if (cutnode)
+                    fext = -CUTNODE_NE_RED;  // cutnode negative extensions
+                else if (ttentry.score >= beta)
+                    fext = -NE_RED;  // negative extensions
+
+            } else if (
+                fdepth <= LDSE_MAX_DEPTH && !in_check && ss->static_eval <= alpha - LDSE_MARGIN
+                && ttentry.flag == tt_.LOWER
+            )
+                fext = LDSE_EXT;  // low depth singular extensions
         }
 
         const u64 old_nodes = tm_.get_nodes(thread_id);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -263,6 +263,9 @@ Tunable(DE_EXT, 138, 64, 256, true);
 Tunable(TE_EXT, 106, 64, 256, true);
 Tunable(NE_RED, 136, 64, 256, true);
 Tunable(CUTNODE_NE_RED, 128, 64, 256, true);
+Tunable(LDSE_MAX_DEPTH, 768, 256, 1024, true);
+Tunable(LDSE_MARGIN, 30, 8, 64, false);
+Tunable(LDSE_EXT, 128, 64, 256, true);
 
 Tunable(LMR_MIN_DEPTH, 372, 128, 640, true);
 Tunable(LMR_FROMMOVE, 5, 2, 8, false);


### PR DESCRIPTION
```
Elo   | 2.19 +- 1.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 41024 W: 9431 L: 9173 D: 22420
Penta | [106, 4845, 10353, 5101, 107]
```
https://rmeguro.pythonanywhere.com/test/426/
bench: 7369629