### PR TITLE
feat: use tt score in razoring

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -499,7 +499,7 @@ i32 Raphael::negamax(
         const i32 razor_margin
             = RAZOR_MARGIN_BASE
               + RAZOR_MARGIN_DEPTH_MUL * fdepth / DEPTH_SCALE * fdepth / DEPTH_SCALE;
-        if (fdepth <= RAZOR_MAX_DEPTH && alpha <= 2048 && ss->static_eval + razor_margin <= alpha) {
+        if (fdepth <= RAZOR_MAX_DEPTH && alpha <= 2048 && score_estimate + razor_margin <= alpha) {
             const i32 score = quiescence<false>(tdata, ply, alpha, alpha + 1, mv);
             if (score <= alpha) return score;
         }


### PR DESCRIPTION
```
Elo   | 3.84 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 13828 W: 3164 L: 3011 D: 7653
Penta | [24, 1579, 3577, 1688, 46]
```
https://rmeguro.pythonanywhere.com/test/441/
bench: 7234186