### PR TITLE
feat: only do tt cutoff if score <= alpha or cutnode

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -439,7 +439,7 @@ i32 Raphael::negamax(
         tthit = tt_.get(ttentry, ttkey, ply);
 
         // tt cutoff
-        if (!is_PV && tthit && ttentry.fdepth >= fdepth
+        if (!is_PV && tthit && ttentry.fdepth >= fdepth && (ttentry.score <= alpha || cutnode)
             && (ttentry.flag == tt_.EXACT                                 // exact
                 || (ttentry.flag == tt_.LOWER && ttentry.score >= beta)   // lower
                 || (ttentry.flag == tt_.UPPER && ttentry.score <= alpha)  // upper


### PR DESCRIPTION
```
Elo   | 8.50 +- 4.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5028 W: 1213 L: 1090 D: 2725
Penta | [19, 529, 1296, 650, 20]
```
https://rmeguro.pythonanywhere.com/test/448/
bench: 7079956