### PR TITLE
feat: vbmi2 sparse masking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,8 @@ endif
 #---------------------------------------------------------------------------------------------------
 
 CCFLAGS_NATIVE      := -march=native
-CCFLAGS_AVX512_VNNI := -march=cascadelake -mbmi2 -DCHESS_USE_PEXT
-CCFLAGS_AVX512      := -march=skylake-avx512 -mbmi2 -DCHESS_USE_PEXT
+CCFLAGS_AVX512_VNNI := -march=icelake-client -DCHESS_USE_PEXT
+CCFLAGS_AVX512      := -march=skylake-avx512 -DCHESS_USE_PEXT
 CCFLAGS_AVX2_BMI2   := -march=haswell -DCHESS_USE_PEXT
 CCFLAGS_AVX2        := -march=haswell -mno-bmi2
 CCFLAGS_GENERIC     := -march=x86-64

--- a/src/Raphael/nnue.cpp
+++ b/src/Raphael/nnue.cpp
@@ -223,7 +223,7 @@ void Nnue::SparseIterator::add_nonzeros(VecU8 l0_out0, VecU8 l0_out1) {
 
     #ifdef __AVX512VBMI2__
     static_assert(USE_SIMD == 512);
-    u32 mask = _mm512_kunpackw(nonzero_mask(l0_out1), nonzero_mask(l0_out0));
+    const auto mask = _mm512_kunpackw(nonzero_mask(l0_out1), nonzero_mask(l0_out0));
 
     const auto idxs = _mm512_maskz_compress_epi16(mask, offset_);
     _mm512_storeu_si512(&indices_[count_], idxs);

--- a/src/Raphael/nnue.cpp
+++ b/src/Raphael/nnue.cpp
@@ -217,15 +217,23 @@ void Nnue::NnueAccumulator::refresh_from(const NnueFinnyEntry& finny_entry) {
 }
 
 #ifdef USE_SIMD
-Nnue::SparseIterator::SparseIterator(): offset_(_mm_setzero_si128()) {}
-
-void Nnue::SparseIterator::add_nonzeros(VecU8 l0_out) {
+void Nnue::SparseIterator::add_nonzeros(VecU8 l0_out0, VecU8 l0_out1) {
     constexpr i32 regw32 = ALIGNMENT / sizeof(i32);
     static_assert(regw32 % 8 == 0);
 
-    u32 full_mask = nonzero_mask(l0_out);
+    #ifdef __AVX512VBMI2__
+    static_assert(USE_SIMD == 512);
+    u32 mask = _mm512_kunpackw(nonzero_mask(l0_out1), nonzero_mask(l0_out0));
 
-    for (i32 i = 0; i < regw32 / 8; i++) {
+    const auto idxs = _mm512_maskz_compress_epi16(mask, offset_);
+    _mm512_storeu_si512(&indices_[count_], idxs);
+    offset_ = add_i16(offset_, full_i16(32));
+    count_ += popcount(mask);
+
+    #else
+    u32 full_mask = (nonzero_mask(l0_out1) << regw32) | nonzero_mask(l0_out0);
+
+    for (i32 i = 0; i < regw32 / 4; i++) {
         // get offset of up to 8 nonzeros at a time
         const u8 mask = full_mask & 0xFF;
         full_mask >>= 8;
@@ -237,6 +245,7 @@ void Nnue::SparseIterator::add_nonzeros(VecU8 l0_out) {
         offset_ = _mm_add_epi16(offset_, _mm_set1_epi16(8));
         count_ += popcount(mask);
     }
+    #endif
 
     assert(count_ <= L1_SIZE / 4);
 }
@@ -455,8 +464,7 @@ void Nnue::activate_l0(
         store_u8(&l0_out[(i + 2) * regw16], out1);
 
         // track nonzero blocks
-        sp.add_nonzeros(out0);
-        sp.add_nonzeros(out1);
+        sp.add_nonzeros(out0, out1);
     }
 #else
     for (i32 i = 0; i < n_pairs; i++) {

--- a/src/Raphael/nnue.h
+++ b/src/Raphael/nnue.h
@@ -170,7 +170,17 @@ private:
     private:
         u16 indices_[L1_SIZE / 4] = {};
         i32 count_ = 0;
-        __m128i offset_;
+
+    #ifdef __AVX512VBMI2__
+        // clang-format off
+        __m512i offset_ = _mm512_set_epi16(
+            31, 30, 29, 28, 27, 26, 25, 24,
+            23, 22, 21, 20, 19, 18, 17, 16,
+            15, 14, 13, 12, 11, 10,  9,  8,
+             7,  6,  5,  4,  3,  2,  1,  0
+        );  // clang-format on
+    #else
+        __m128i offset_ = _mm_setzero_si128();
 
         // precompute nonzero_idx[mask][nnz_idx] = position of nonzero block
         alignas(16) static constexpr MultiArray<u16, 256, 8> nonzero_idx = [] {
@@ -185,17 +195,16 @@ private:
 
             return idx;
         }();
+    #endif
 
 
     public:
-        /** Initializes the sparse iterator */
-        SparseIterator();
-
         /** Adds the nonzero indices to the sparse iterator
          *
-         * \param l0_out a chunk of l0 outputs
+         * \param l0_out0 first chunk of l0 outputs
+         * \param l0_out1 second chunk of l0 outputs
          */
-        void add_nonzeros(VecU8 l0_out);
+        void add_nonzeros(VecU8 l0_out0, VecU8 l0_out1);
 
         /** Returns the number of nonezero blocks
          *

--- a/src/Raphael/simd.h
+++ b/src/Raphael/simd.h
@@ -18,61 +18,49 @@ using VecI32 = __m512i;  // a list of 16x i32
  * \param src an array of 64x u8 elements
  * \returns the loaded register
  */
-inline VecU8 load_u8(const u8* src) {
-    return _mm512_load_si512(reinterpret_cast<const VecU8*>(src));
-}
+inline VecU8 load_u8(const u8* src) { return _mm512_load_si512(src); }
 
 /** Loads an i8[64] array into a VecI8 register
  *
  * \param src an array of 64x i8 elements
  * \returns the loaded register
  */
-inline VecI8 load_i8(const i8* src) {
-    return _mm512_load_si512(reinterpret_cast<const VecI8*>(src));
-}
+inline VecI8 load_i8(const i8* src) { return _mm512_load_si512(src); }
 
 /** Loads an i16[32] array into a VecI16 register
  *
  * \param src an array of 32x i16 elements
  * \returns the loaded register
  */
-inline VecI16 load_i16(const i16* src) {
-    return _mm512_load_si512(reinterpret_cast<const VecI16*>(src));
-}
+inline VecI16 load_i16(const i16* src) { return _mm512_load_si512(src); }
 
 /** Loads an i32[16] array into a VecI32 register
  *
  * \param src an array of 16x i32 elements
  * \returns the loaded register
  */
-inline VecI32 load_i32(const i32* src) {
-    return _mm512_load_si512(reinterpret_cast<const VecI32*>(src));
-}
+inline VecI32 load_i32(const i32* src) { return _mm512_load_si512(src); }
 
 /** Stores a VecU8 register into a u8[64] array
  *
  * \param dst the array of 64x u8 elements to store into
  * \param src the register to store
  */
-inline void store_u8(u8* dst, VecU8 src) { _mm512_store_si512(reinterpret_cast<VecU8*>(dst), src); }
+inline void store_u8(u8* dst, VecU8 src) { _mm512_store_si512(dst, src); }
 
 /** Stores a VecI16 register into an i16[32] array
  *
  * \param dst the array of 32x i16 elements to store into
  * \param src the register to store
  */
-inline void store_i16(i16* dst, VecI16 src) {
-    _mm512_store_si512(reinterpret_cast<VecI16*>(dst), src);
-}
+inline void store_i16(i16* dst, VecI16 src) { _mm512_store_si512(dst, src); }
 
 /** Stores a VecI32 register into an i32[16] array
  *
  * \param dst the array of 16x i32 elements to store into
  * \param src the register to store
  */
-inline void store_i32(i32* dst, VecI32 src) {
-    _mm512_store_si512(reinterpret_cast<VecI32*>(dst), src);
-}
+inline void store_i32(i32* dst, VecI32 src) { _mm512_store_si512(dst, src); }
 
 /** Returns a VecI16 register with all zeros
  *


### PR DESCRIPTION
from: https://github.com/official-stockfish/Stockfish/pull/6186
```
Elo   | 10.21 +- 5.35 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4152 W: 1021 L: 899 D: 2232
Penta | [12, 412, 1119, 508, 25]
```
https://rmeguro.pythonanywhere.com/test/479/
bench: 7039109