### PR TITLE
fix: pass board by reference

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -32,7 +32,7 @@ using std::swap;
 
 
 
-const string Raphael::version = "4.0.0";
+const string Raphael::version = "4.1.0-dev";
 
 const Raphael::EngineOptions& Raphael::default_params() {
     static EngineOptions opts{

--- a/src/Raphael/position.h
+++ b/src/Raphael/position.h
@@ -60,7 +60,7 @@ public:
      *
      * \returns current board
      */
-    const chess::Board board() const { return current_; }
+    const chess::Board& board() const { return current_; }
 
 
     /** Returns a move n plies ago, or NO_MOVE, Piece::NONE if ply > number of moves played


### PR DESCRIPTION
```
Elo   | 9.45 +- 5.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4264 W: 1052 L: 936 D: 2276
Penta | [5, 426, 1162, 526, 13]
```
https://rmeguro.pythonanywhere.com/test/499/
bench: 7039109