### PR TITLE
feat: update corrhist even in singular search

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -766,14 +766,16 @@ i32 Raphael::negamax(
     // terminal analysis
     if (move_searched == 0) return (in_check) ? -MATE_SCORE + ply : 0;  // reward faster mate
 
-    // update transposition table
-    if (!ss->excluded && !stop_.load(memory_order_relaxed)) {
+    if (!stop_.load(memory_order_relaxed)) {
+        // update transposition table
+        if (!ss->excluded)
+            tt_.set(ttkey, bestscore, raw_static_eval, bestmove, fdepth, ss->ttpv, ttflag, ply);
+
         // update corrhist
-        if (!in_check && (bestmove == chess::Move::NO_MOVE || board.is_quiet(bestmove))
+        if (!in_check && (!bestmove || board.is_quiet(bestmove))
             && (ttflag == tt_.EXACT || (ttflag == tt_.LOWER && bestscore > ss->static_eval)
                 || (ttflag == tt_.UPPER && bestscore < ss->static_eval)))
             history.update_corrections(position, fdepth, bestscore, ss->static_eval);
-        tt_.set(ttkey, bestscore, raw_static_eval, bestmove, fdepth, ss->ttpv, ttflag, ply);
     }
 
     return bestscore;


### PR DESCRIPTION
```
Elo   | 3.39 +- 2.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.17 (-2.25, 2.89) [0.00, 5.00]
Games | N: 18030 W: 4178 L: 4002 D: 9850
Penta | [32, 2058, 4668, 2216, 41]
```
https://rmeguro.pythonanywhere.com/test/518/
bench: 7220261