### PR TITLE
feat: simplify out killers

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ To see all supported commands, run `uci.exe help`
     - [x] MVV-LVA                           (`v1.0+`)
     - [x] Promotions                        (`v1.0+`)
     - [x] Hash move                         (`v1.6+`)
-    - [x] Killer heuristics                 (`v1.3+`)
+    - ~~[x] Killer heuristics~~             (`v1.3+`)
     - [x] Butterfly history                 (`v1.5+`)
     - [x] Capture history                   (`v2.3+`)
     - [ ] Piece-to history

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -548,12 +548,11 @@ i32 Raphael::negamax(
     // initialize move generator
     mv->quietlist.clear();
     mv->noisylist.clear();
-    auto generator = MoveGenerator::negamax(&mv->movelist, &position, &history, ttmove, ss->killer);
+    auto generator = MoveGenerator::negamax(&mv->movelist, &position, &history, ttmove);
 
     // search
     i32 bestscore = -INF_SCORE;
     chess::Move bestmove = chess::Move::NO_MOVE;
-    (ss + 1)->killer = chess::Move::NO_MOVE;
     auto ttflag = tt_.UPPER;
 
     i32 move_searched = 0;
@@ -711,9 +710,6 @@ i32 Raphael::negamax(
                         = fdepth + (!in_check && ss->static_eval <= alpha) * DEPTH_SCALE;
 
                     if (is_quiet) {
-                        // store killer moves and update quiet history
-                        ss->killer = move;
-
                         const i32 bonus = history.bonus(
                             history_fdepth,
                             HISTORY_BONUS_DEPTH_MUL,

--- a/src/Raphael/Raphael.h
+++ b/src/Raphael/Raphael.h
@@ -69,7 +69,6 @@ private:
         PVList pv;
         i32 static_eval = 0;
         chess::Move move = chess::Move::NO_MOVE;
-        chess::Move killer = chess::Move::NO_MOVE;
         chess::Move excluded = chess::Move::NO_MOVE;
         i16 freductions = 0;
         bool ttpv;

--- a/src/Raphael/movepick.cpp
+++ b/src/Raphael/movepick.cpp
@@ -12,10 +12,9 @@ MoveGenerator MoveGenerator::negamax(
     chess::MoveList<chess::ScoredMove>* movelist,
     const Position<true>* position,
     const History* history,
-    chess::Move ttmove,
-    chess::Move killer
+    chess::Move ttmove
 ) {
-    return MoveGenerator(Stage::TT_MOVE, movelist, position, history, ttmove, killer);
+    return MoveGenerator(Stage::TT_MOVE, movelist, position, history, ttmove);
 }
 
 MoveGenerator MoveGenerator::quiescence(
@@ -26,9 +25,7 @@ MoveGenerator MoveGenerator::quiescence(
 ) {
     const auto& board = position->board();
 
-    auto generator = MoveGenerator(
-        Stage::QS_TT_MOVE, movelist, position, history, ttmove, chess::Move::NO_MOVE
-    );
+    auto generator = MoveGenerator(Stage::QS_TT_MOVE, movelist, position, history, ttmove);
     if (!board.in_check()) generator.skip_quiets();
 
     return generator;
@@ -76,16 +73,7 @@ chess::Move MoveGenerator::next() {
             }
 
             // good noisies exhausted
-            stage_ = Stage::KILLER;
-            [[fallthrough]];
-        }
-
-        case Stage::KILLER: {
             stage_ = Stage::GEN_QUIET;
-
-            if (!skip_quiets_ && killer_ && killer_ != ttmove_ && board.is_legal(killer_))
-                return killer_;
-
             [[fallthrough]];
         }
 
@@ -106,12 +94,12 @@ chess::Move MoveGenerator::next() {
 
         case Stage::QUIET: {
             if (!skip_quiets_) {
-                // find next non-tt, non-killer quiet move
+                // find next non-tt quiet move
                 while (idx_ < end_) {
                     const auto idx = select_next();
                     const auto& smove = (*movelist_)[idx];
 
-                    if (smove.move == ttmove_ || smove.move == killer_) continue;
+                    if (smove.move == ttmove_) continue;
 
                     return smove.move;
                 }
@@ -220,15 +208,13 @@ MoveGenerator::MoveGenerator(
     chess::MoveList<chess::ScoredMove>* movelist,
     const Position<true>* position,
     const History* history,
-    chess::Move ttmove,
-    chess::Move killer
+    chess::Move ttmove
 )
     : stage_(start_stage),
       movelist_(movelist),
       position_(position),
       history_(history),
-      ttmove_(ttmove),
-      killer_(killer) {
+      ttmove_(ttmove) {
     movelist_->clear();
 }
 

--- a/src/Raphael/movepick.h
+++ b/src/Raphael/movepick.h
@@ -12,7 +12,6 @@ public:
         TT_MOVE,
         GEN_NOISY,
         GOOD_NOISY,
-        KILLER,
         GEN_QUIET,
         QUIET,
         BAD_NOISY,
@@ -32,7 +31,6 @@ private:
     const Position<true>* position_;
     const History* history_;
     chess::Move ttmove_ = chess::Move::NO_MOVE;
-    chess::Move killer_ = chess::Move::NO_MOVE;
 
     bool skip_quiets_ = false;
     usize idx_ = 0;
@@ -47,15 +45,13 @@ public:
      * \param position pointer to current position
      * \param history pointer to history table
      * \param ttmove transposition table move
-     * \param killer killer move
      * \returns the move generator
      */
     static MoveGenerator negamax(
         chess::MoveList<chess::ScoredMove>* movelist,
         const Position<true>* position,
         const History* history,
-        chess::Move ttmove,
-        chess::Move killer
+        chess::Move ttmove
     );
 
     /** Initializes a move generator for the quiescence search
@@ -91,15 +87,13 @@ private:
      * \param position pointer to current position
      * \param history pointer to history table
      * \param ttmove transposition table move
-     * \param killer killer move
      */
     MoveGenerator(
         Stage start_stage,
         chess::MoveList<chess::ScoredMove>* movelist,
         const Position<true>* position,
         const History* history,
-        chess::Move ttmove,
-        chess::Move killer
+        chess::Move ttmove
     );
 
 


### PR DESCRIPTION
```
Elo   | 0.05 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.14 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 29246 W: 6633 L: 6629 D: 15984
Penta | [52, 3470, 7589, 3446, 66]
```
https://rmeguro.pythonanywhere.com/test/513/

```
Elo   | -0.18 +- 1.82 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 32942 W: 7430 L: 7447 D: 18065
Penta | [16, 3829, 8798, 3812, 16]
```
https://rmeguro.pythonanywhere.com/test/514/

bench: 7409854