### PR TITLE
feat: 2-ply contcorrhist

### DIFF
--- a/src/Raphael/History.cpp
+++ b/src/Raphael/History.cpp
@@ -122,6 +122,7 @@ void History::update_corrections(
     const auto& board = position.board();
     const auto curr = position.prev_move(1);
     const auto prev1 = position.prev_move(2);
+    const auto prev2 = position.prev_move(3);
 
     pawn_corr_entry(board).update(bonus);
     major_corr_entry(board).update(bonus);
@@ -129,12 +130,15 @@ void History::update_corrections(
     nonpawn_corr_entry(board, chess::Color::BLACK).update(bonus);
     if (curr.moving != chess::Piece::NONE && prev1.moving != chess::Piece::NONE)
         cont_corr_entry(curr.move, curr.moving, prev1).update(bonus);
+    if (curr.moving != chess::Piece::NONE && prev2.moving != chess::Piece::NONE)
+        cont_corr_entry(curr.move, curr.moving, prev2).update(bonus);
 }
 
 i32 History::correct(const Position<true>& position, i32 score) const {
     const auto& board = position.board();
     const auto curr = position.prev_move(1);
     const auto prev1 = position.prev_move(2);
+    const auto prev2 = position.prev_move(3);
 
     i32 correction = 0;
     correction += pawn_corr_entry(board) * PAWN_CORRHIST_WEIGHT;
@@ -143,6 +147,9 @@ i32 History::correct(const Position<true>& position, i32 score) const {
     correction += nonpawn_corr_entry(board, chess::Color::BLACK) * NONPAWN_CORRHIST_WEIGHT;
     correction += (curr.moving != chess::Piece::NONE && prev1.moving != chess::Piece::NONE)
                       ? cont_corr_entry(curr.move, curr.moving, prev1) * CONT1_CORRHIST_WEIGHT
+                      : 0;
+    correction += (curr.moving != chess::Piece::NONE && prev2.moving != chess::Piece::NONE)
+                      ? cont_corr_entry(curr.move, curr.moving, prev2) * CONT2_CORRHIST_WEIGHT
                       : 0;
     correction /= CORRHIST_MAX;
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -340,6 +340,7 @@ Tunable(PAWN_CORRHIST_WEIGHT, 50, 32, 384, true);
 Tunable(MAJOR_CORRHIST_WEIGHT, 41, 32, 384, true);
 Tunable(NONPAWN_CORRHIST_WEIGHT, 39, 32, 384, true);
 Tunable(CONT1_CORRHIST_WEIGHT, 63, 32, 384, true);
+Tunable(CONT2_CORRHIST_WEIGHT, 48, 32, 384, true);
 
 // eval scaling
 Tunable(MAT_SCALE_BASE, 25100, 20000, 30000, false);


### PR DESCRIPTION
```
Elo   | 1.85 +- 1.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 63024 W: 14607 L: 14272 D: 34145
Penta | [141, 7400, 16099, 7727, 145]
```
https://rmeguro.pythonanywhere.com/test/528/

```
Elo   | 2.14 +- 2.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.35 (-2.25, 2.89) [0.00, 5.00]
Games | N: 16378 W: 3721 L: 3620 D: 9037
Penta | [7, 1793, 4487, 1896, 6]
```
https://rmeguro.pythonanywhere.com/test/531/
bench: 7269109