### PR TITLE
feat: corrplexity lmr

### DIFF
--- a/src/Raphael/History.cpp
+++ b/src/Raphael/History.cpp
@@ -134,7 +134,7 @@ void History::update_corrections(
         cont_corr_entry(curr.move, curr.moving, prev2).update(bonus);
 }
 
-i32 History::correct(const Position<true>& position, i32 score) const {
+i32 History::get_correction(const Position<true>& position) const {
     const auto& board = position.board();
     const auto curr = position.prev_move(1);
     const auto prev1 = position.prev_move(2);
@@ -153,7 +153,7 @@ i32 History::correct(const Position<true>& position, i32 score) const {
                       : 0;
     correction /= CORRHIST_MAX;
 
-    return score + correction;
+    return correction;
 }
 
 

--- a/src/Raphael/History.h
+++ b/src/Raphael/History.h
@@ -115,13 +115,12 @@ public:
      */
     void update_corrections(const Position<true>& position, i32 fdepth, i32 score, i32 static_eval);
 
-    /** Returns the corrected score
+    /** Returns the correction term
      *
      * \param position current position
-     * \param score score to correct
-     * \returns the corrected score
+     * \returns the correction term
      */
-    i32 correct(const Position<true>& position, i32 score) const;
+    i32 get_correction(const Position<true>& position) const;
 
 
     /** Zeros out all the histories */

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -460,7 +460,7 @@ i32 Raphael::negamax(
     const bool in_check = board.in_check();
     i32 raw_static_eval;
     i32 score_estimate;
-    i32 corrplexity;
+    i32 corrplexity = 0;
 
     if (!ss->excluded) {
         if (in_check) {
@@ -796,7 +796,7 @@ i32 Raphael::quiescence(ThreadData& tdata, const i32 ply, i32 alpha, i32 beta, M
 
     // max ply
     const bool in_check = board.in_check();
-    i32 corrplexity;
+    i32 corrplexity = 0;
     if (ply >= MAX_DEPTH - 1)
         return (in_check) ? 0
                           : adjust_score(tdata, position.evaluate(!params_.datagen), corrplexity);

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -193,8 +193,9 @@ i32 Raphael::static_eval(bool corrected) {
     assert(thread_data_.size() >= 1);
 
     auto& tdata = *thread_data_[0];
+    i32 corrplexity;
     const auto raw_score = tdata.position_.evaluate(!params_.datagen);
-    return (corrected) ? adjust_score(tdata, raw_score) : raw_score;
+    return (corrected) ? adjust_score(tdata, raw_score, corrplexity) : raw_score;
 }
 
 
@@ -296,7 +297,7 @@ string Raphael::get_pv_line(const PVList& pv) const {
 }
 
 
-i32 Raphael::adjust_score(const ThreadData& tdata, i32 raw_static_eval) const {
+i32 Raphael::adjust_score(const ThreadData& tdata, i32 raw_static_eval, i32& corrplexity) const {
     const auto& position = tdata.position_;
     const auto& history = tdata.history;
     const auto& board = position.board();
@@ -305,7 +306,9 @@ i32 Raphael::adjust_score(const ThreadData& tdata, i32 raw_static_eval) const {
     if (!params_.datagen) raw_static_eval = raw_static_eval * (200 - board.halfmoves()) / 200;
 
     // corrhist
-    raw_static_eval = history.correct(position, raw_static_eval);
+    const i32 correction = history.get_correction(position);
+    raw_static_eval = raw_static_eval + correction;
+    corrplexity = abs(correction);
 
     return clamp(raw_static_eval, -MATE_SCORE + 1, MATE_SCORE - 1);
 }
@@ -457,6 +460,7 @@ i32 Raphael::negamax(
     const bool in_check = board.in_check();
     i32 raw_static_eval;
     i32 score_estimate;
+    i32 corrplexity;
 
     if (!ss->excluded) {
         if (in_check) {
@@ -471,7 +475,7 @@ i32 Raphael::negamax(
                 tt_.set_static_eval(ttkey, raw_static_eval);
             }
 
-            ss->static_eval = adjust_score(tdata, raw_static_eval);
+            ss->static_eval = adjust_score(tdata, raw_static_eval, corrplexity);
             score_estimate = ss->static_eval;
 
             if (tthit
@@ -656,6 +660,7 @@ i32 Raphael::negamax(
             fred -= improving * LMR_IMPROVING;
             fred -= gives_check * LMR_CHECK;
             fred -= hist * DEPTH_SCALE / ((is_quiet) ? LMR_QUIET_HIST_DIV : LMR_NOISY_HIST_DIV);
+            fred -= corrplexity * DEPTH_SCALE / LMR_CORRPLEXITY_DIV;
 
             ss->freductions = fred;
             const i32 red_fdepth = min(max(new_fdepth - fred, DEPTH_SCALE), new_fdepth);
@@ -791,8 +796,10 @@ i32 Raphael::quiescence(ThreadData& tdata, const i32 ply, i32 alpha, i32 beta, M
 
     // max ply
     const bool in_check = board.in_check();
+    i32 corrplexity;
     if (ply >= MAX_DEPTH - 1)
-        return (in_check) ? 0 : adjust_score(tdata, position.evaluate(!params_.datagen));
+        return (in_check) ? 0
+                          : adjust_score(tdata, position.evaluate(!params_.datagen), corrplexity);
 
     // probe transposition table
     const auto ttkey = board.hash();
@@ -824,7 +831,7 @@ i32 Raphael::quiescence(ThreadData& tdata, const i32 ply, i32 alpha, i32 beta, M
             tt_.set_static_eval(ttkey, raw_static_eval);
         }
 
-        static_eval = adjust_score(tdata, raw_static_eval);
+        static_eval = adjust_score(tdata, raw_static_eval, corrplexity);
 
         if (static_eval >= beta) return static_eval;
 

--- a/src/Raphael/Raphael.h
+++ b/src/Raphael/Raphael.h
@@ -239,9 +239,10 @@ private:
      *
      * \param tdata this thread's data
      * \param raw_static_eval raw eval to adjust
+     * \param corrplexity reference to store abs correction into
      * \returns the adjusted eval
      */
-    i32 adjust_score(const ThreadData& tdata, i32 raw_static_eval) const;
+    i32 adjust_score(const ThreadData& tdata, i32 raw_static_eval, i32& corrplexity) const;
 
 
     /** Does the actual search logic, calling negamax with increasing depth.

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -282,7 +282,7 @@ Tunable(LMR_IMPROVING, 84, 32, 384, true);
 Tunable(LMR_CHECK, 154, 32, 384, true);
 Tunable(LMR_QUIET_HIST_DIV, 11520, 4096, 16384, true);
 Tunable(LMR_NOISY_HIST_DIV, 9709, 4096, 16384, true);
-Tunable(LMR_CORRPLEXITY_DIV, 700, 128, 1024, true);
+Tunable(LMR_CORRPLEXITY_DIV, 300, 128, 1024, true);
 
 Tunable(DO_DEEPER_BASE, 40, 0, 128, false);
 Tunable(DO_DEEPER_DEPTH_MUL, 6, 1, 12, false);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -282,6 +282,7 @@ Tunable(LMR_IMPROVING, 84, 32, 384, true);
 Tunable(LMR_CHECK, 154, 32, 384, true);
 Tunable(LMR_QUIET_HIST_DIV, 11520, 4096, 16384, true);
 Tunable(LMR_NOISY_HIST_DIV, 9709, 4096, 16384, true);
+Tunable(LMR_CORRPLEXITY_DIV, 512, 128, 1024, true);
 
 Tunable(DO_DEEPER_BASE, 40, 0, 128, false);
 Tunable(DO_DEEPER_DEPTH_MUL, 6, 1, 12, false);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -282,7 +282,7 @@ Tunable(LMR_IMPROVING, 84, 32, 384, true);
 Tunable(LMR_CHECK, 154, 32, 384, true);
 Tunable(LMR_QUIET_HIST_DIV, 11520, 4096, 16384, true);
 Tunable(LMR_NOISY_HIST_DIV, 9709, 4096, 16384, true);
-Tunable(LMR_CORRPLEXITY_DIV, 512, 128, 1024, true);
+Tunable(LMR_CORRPLEXITY_DIV, 700, 128, 1024, true);
 
 Tunable(DO_DEEPER_BASE, 40, 0, 128, false);
 Tunable(DO_DEEPER_DEPTH_MUL, 6, 1, 12, false);


### PR DESCRIPTION
```
Elo   | 2.56 +- 2.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 27252 W: 6294 L: 6093 D: 14865
Penta | [51, 3104, 7115, 3305, 51]
```
https://rmeguro.pythonanywhere.com/test/537/
bench: 7270814