### PR TITLE
feat: corrplexity rfp

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -497,7 +497,7 @@ i32 Raphael::negamax(
         // reverse futility pruning
         const i32 rfp_margin = RFP_MARGIN_DEPTH_MUL * fdepth / DEPTH_SCALE
                                - improving * RFP_MARGIN_IMPROVING
-                               + corrplexity * RFP_MARGIN_CORRPLEXITY / 128;
+                               + corrplexity * RFP_MARGIN_CORRPLEXITY / 1024;
         if (fdepth <= RFP_MAX_DEPTH && score_estimate - rfp_margin >= beta) return score_estimate;
 
         // razoring

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -495,8 +495,9 @@ i32 Raphael::negamax(
             fdepth += HINDSIGHT_EXT;
 
         // reverse futility pruning
-        const i32 rfp_margin
-            = RFP_MARGIN_DEPTH_MUL * fdepth / DEPTH_SCALE - RFP_MARGIN_IMPROVING * improving;
+        const i32 rfp_margin = RFP_MARGIN_DEPTH_MUL * fdepth / DEPTH_SCALE
+                               - improving * RFP_MARGIN_IMPROVING
+                               + corrplexity * RFP_MARGIN_CORRPLEXITY / 128;
         if (fdepth <= RFP_MAX_DEPTH && score_estimate - rfp_margin >= beta) return score_estimate;
 
         // razoring

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -226,7 +226,7 @@ Tunable(HINDSIGHT_EXT, 123, 64, 256, true);
 Tunable(RFP_MAX_DEPTH, 921, 128, 1280, true);
 Tunable(RFP_MARGIN_DEPTH_MUL, 44, 16, 128, true);
 Tunable(RFP_MARGIN_IMPROVING, 29, 16, 128, true);
-Tunable(RFP_MARGIN_CORRPLEXITY, 64, 16, 128, true);
+Tunable(RFP_MARGIN_CORRPLEXITY, 32, 16, 128, true);
 
 Tunable(RAZOR_MAX_DEPTH, 602, 128, 1280, true);
 Tunable(RAZOR_MARGIN_DEPTH_MUL, 243, 32, 384, true);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -226,7 +226,7 @@ Tunable(HINDSIGHT_EXT, 123, 64, 256, true);
 Tunable(RFP_MAX_DEPTH, 921, 128, 1280, true);
 Tunable(RFP_MARGIN_DEPTH_MUL, 44, 16, 128, true);
 Tunable(RFP_MARGIN_IMPROVING, 29, 16, 128, true);
-Tunable(RFP_MARGIN_CORRPLEXITY, 32, 16, 128, true);
+Tunable(RFP_MARGIN_CORRPLEXITY, 128, 32, 384, true);
 
 Tunable(RAZOR_MAX_DEPTH, 602, 128, 1280, true);
 Tunable(RAZOR_MARGIN_DEPTH_MUL, 243, 32, 384, true);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -226,7 +226,7 @@ Tunable(HINDSIGHT_EXT, 123, 64, 256, true);
 Tunable(RFP_MAX_DEPTH, 921, 128, 1280, true);
 Tunable(RFP_MARGIN_DEPTH_MUL, 44, 16, 128, true);
 Tunable(RFP_MARGIN_IMPROVING, 29, 16, 128, true);
-Tunable(RFP_MARGIN_CORRPLEXITY, 128, 32, 384, true);
+Tunable(RFP_MARGIN_CORRPLEXITY, 100, 32, 384, true);
 
 Tunable(RAZOR_MAX_DEPTH, 602, 128, 1280, true);
 Tunable(RAZOR_MARGIN_DEPTH_MUL, 243, 32, 384, true);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -226,6 +226,7 @@ Tunable(HINDSIGHT_EXT, 123, 64, 256, true);
 Tunable(RFP_MAX_DEPTH, 921, 128, 1280, true);
 Tunable(RFP_MARGIN_DEPTH_MUL, 44, 16, 128, true);
 Tunable(RFP_MARGIN_IMPROVING, 29, 16, 128, true);
+Tunable(RFP_MARGIN_CORRPLEXITY, 64, 16, 128, true);
 
 Tunable(RAZOR_MAX_DEPTH, 602, 128, 1280, true);
 Tunable(RAZOR_MARGIN_DEPTH_MUL, 243, 32, 384, true);


### PR DESCRIPTION
```
Elo   | 2.55 +- 2.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 28564 W: 6690 L: 6480 D: 15394
Penta | [56, 3284, 7376, 3526, 40]
```
https://rmeguro.pythonanywhere.com/test/539/
bench: 7314163