### PR TITLE
feat: decrease rfp margin if opponent worsening

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -486,17 +486,20 @@ i32 Raphael::negamax(
         }
     }
     const bool improving = !in_check && ss->static_eval > (ss - 2)->static_eval;
+    const i32 opp_worsening_rate
+        = (is_root || in_check) ? 0 : ss->static_eval + (ss - 1)->static_eval;
 
     // pre-moveloop pruning
     if (!is_PV && !in_check && !ss->excluded) {
         // hindsight extension
         if ((ss - 1)->freductions >= HINDSIGHT_MIN_RED && (ss - 1)->static_eval != NONE_SCORE
-            && ss->static_eval <= -(ss - 1)->static_eval)
+            && opp_worsening_rate <= 0)
             fdepth += HINDSIGHT_EXT;
 
         // reverse futility pruning
         const i32 rfp_margin = RFP_MARGIN_DEPTH_MUL * fdepth / DEPTH_SCALE
                                - improving * RFP_MARGIN_IMPROVING
+                               - (opp_worsening_rate > 0) * RFP_MARGIN_OPP_WORSENING
                                + corrplexity * RFP_MARGIN_CORRPLEXITY / 1024;
         if (fdepth <= RFP_MAX_DEPTH && score_estimate - rfp_margin >= beta) return score_estimate;
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -224,8 +224,9 @@ Tunable(HINDSIGHT_MIN_RED, 411, 384, 768, true);
 Tunable(HINDSIGHT_EXT, 123, 64, 256, true);
 
 Tunable(RFP_MAX_DEPTH, 921, 128, 1280, true);
-Tunable(RFP_MARGIN_DEPTH_MUL, 44, 16, 128, true);
-Tunable(RFP_MARGIN_IMPROVING, 29, 16, 128, true);
+Tunable(RFP_MARGIN_DEPTH_MUL, 44, 0, 128, true);
+Tunable(RFP_MARGIN_IMPROVING, 29, 0, 64, true);
+Tunable(RFP_MARGIN_OPP_WORSENING, 15, 0, 64, true);
 Tunable(RFP_MARGIN_CORRPLEXITY, 100, 32, 384, true);
 
 Tunable(RAZOR_MAX_DEPTH, 602, 128, 1280, true);


### PR DESCRIPTION
```
Elo   | 6.42 +- 3.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.25, 2.89) [0.00, 4.00]
Games | N: 8494 W: 2026 L: 1869 D: 4599
Penta | [13, 946, 2176, 1095, 17]
```
https://rmeguro.pythonanywhere.com/test/546/
bench: 7043210