### PR TITLE
fix: proper mate detection after 50 moves + draw detection in qsearch

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -32,7 +32,7 @@ using std::swap;
 
 
 
-const string Raphael::version = "4.1.1";
+const string Raphael::version = "4.2.0-dev";
 
 const Raphael::EngineOptions& Raphael::default_params() {
     static EngineOptions opts{
@@ -837,6 +837,9 @@ i32 Raphael::quiescence(ThreadData& tdata, const i32 ply, i32 alpha, i32 beta, M
     if (tm_.is_hard_limit_reached(thread_id, stop_)) return 0;
 
     if constexpr (is_PV) tm_.update_seldepth(thread_id, ply);
+
+    // detect draws
+    if (position.is_drawn(ply)) return (tm_.get_nodes(thread_id) & 0x2) - 1;
 
     // max ply
     const bool in_check = board.in_check();

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -419,16 +419,14 @@ i32 Raphael::negamax(
     if constexpr (is_PV) ss->pv.length = 0;
 
     if (!is_root) {
-        // prevent draw in winning positions
-        // technically this ignores checkmate on the 50th move
-        if (position.is_repetition(ply) || board.is_halfmovedraw())
-            return (tm_.get_nodes(thread_id) & 0x2) - 1;
-
         // mate distance pruning
         alpha = max(alpha, -MATE_SCORE + ply);
         beta = min(beta, MATE_SCORE - ply - 1);
         if (alpha >= beta) return alpha;
     }
+
+    // detect draws
+    if (position.is_drawn(ply)) return (tm_.get_nodes(thread_id) & 0x2) - 1;
 
     // terminal depth or max ply
     if (fdepth <= 0 || ply >= MAX_DEPTH - 1) return quiescence<is_PV>(tdata, ply, alpha, beta, mv);
@@ -594,9 +592,6 @@ i32 Raphael::negamax(
             }
         }
     }
-
-    // draw analysis
-    if (board.is_insufficientmaterial()) return (tm_.get_nodes(thread_id) & 0x2) - 1;
 
     // initialize move generator
     mv->quietlist.clear();

--- a/src/Raphael/position.h
+++ b/src/Raphael/position.h
@@ -95,6 +95,26 @@ public:
         return false;
     }
 
+    /** Checks if the position is drawn
+     *
+     * \param ply distance from root
+     * \returns whether the position is drawn
+     */
+    bool is_drawn(i32 ply) const {
+        if (current_.is_halfmovedraw()) {
+            if (!current_.in_check()) return true;
+
+            // TODO: exit as soon as we find one legal move
+            chess::MoveList<chess::ScoredMove> movelist;
+            chess::Movegen::generate_legals(movelist, current_);
+            return !movelist.empty();
+        }
+
+        if (current_.is_insufficientmaterial()) return true;
+
+        return is_repetition(ply);
+    }
+
 
     /** Evaluates the current board from the current side to move
      *

--- a/src/tests/position.cpp
+++ b/src/tests/position.cpp
@@ -168,6 +168,13 @@ TEST_SUITE("Position") {
         CHECK(position.is_repetition(4));
     }
 
+    TEST_CASE("Halfmove Checkmate") {
+        chess::Board board = chess::Board("3nkn2/3nQn2/8/6B1/8/8/8/4K3 b - - 100 1");
+        Position<false> position;
+        position.set_board(board);
+        CHECK(!position.is_drawn(0));
+    }
+
     TEST_CASE("Prev Move") {
         chess::Board board = chess::Board();
         Position<false> position;


### PR DESCRIPTION
```
Elo   | 1.42 +- 2.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 9764 W: 1755 L: 1715 D: 6294
Penta | [1, 408, 4030, 436, 7]
```
https://rmeguro.pythonanywhere.com/test/566/
bench: 9448661