### PR TITLE
feat: increase ldse margin using corrplexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following are the historic elo for Raphael.
   <tr align="center">
     <td>4.1.0     </td> <td>Mar 17, 2026 </td>
     <td>3728*     </td> <td>3582*        </td>
-    <td>          </td> <td>             </td>
+  <td>3555 (#22)</td> <td>             </td>
   </tr>
   <tr align="center">
     <td>4.0.0     </td> <td>Apr 26, 2026 </td>

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -683,11 +683,12 @@ i32 Raphael::negamax(
                 else if (ttentry.score >= beta)
                     fext = -NE_RED;  // negative extensions
 
-            } else if (
-                fdepth <= LDSE_MAX_DEPTH && !in_check && ss->static_eval <= alpha - LDSE_MARGIN
-                && ttentry.flag == tt_.LOWER
-            )
-                fext = LDSE_EXT;  // low depth singular extensions
+            } else if (fdepth <= LDSE_MAX_DEPTH && !in_check && ttentry.flag == tt_.LOWER) {
+                // low depth singular extensions
+                const i32 ldse_margin
+                    = alpha - LDSE_MARGIN_BASE + LDSE_MARGIN_CORRPLEXITY_MUL * corrplexity / 16384;
+                if (ss->static_eval <= ldse_margin) fext = LDSE_EXT;
+            }
         }
 
         const u64 old_nodes = tm_.get_nodes(thread_id);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -274,7 +274,7 @@ Tunable(NE_RED, 118, 64, 256, true);
 Tunable(CUTNODE_NE_RED, 140, 64, 256, true);
 Tunable(LDSE_MAX_DEPTH, 721, 256, 1024, true);
 Tunable(LDSE_MARGIN_BASE, 28, 0, 50, true);
-Tunable(LDSE_MARGIN_CORRPLEXITY_MUL, 128, 64, 256, true);
+Tunable(LDSE_MARGIN_CORRPLEXITY_MUL, 96, 64, 256, true);
 Tunable(LDSE_EXT, 124, 64, 256, true);
 
 Tunable(LMR_MIN_DEPTH, 393, 128, 640, true);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -273,7 +273,8 @@ Tunable(TE_EXT, 86, 64, 256, true);
 Tunable(NE_RED, 118, 64, 256, true);
 Tunable(CUTNODE_NE_RED, 140, 64, 256, true);
 Tunable(LDSE_MAX_DEPTH, 721, 256, 1024, true);
-Tunable(LDSE_MARGIN, 28, 0, 50, true);
+Tunable(LDSE_MARGIN_BASE, 28, 0, 50, true);
+Tunable(LDSE_MARGIN_CORRPLEXITY_MUL, 128, 64, 256, true);
 Tunable(LDSE_EXT, 124, 64, 256, true);
 
 Tunable(LMR_MIN_DEPTH, 393, 128, 640, true);

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -274,7 +274,7 @@ Tunable(NE_RED, 118, 64, 256, true);
 Tunable(CUTNODE_NE_RED, 140, 64, 256, true);
 Tunable(LDSE_MAX_DEPTH, 721, 256, 1024, true);
 Tunable(LDSE_MARGIN_BASE, 28, 0, 50, true);
-Tunable(LDSE_MARGIN_CORRPLEXITY_MUL, 96, 64, 256, true);
+Tunable(LDSE_MARGIN_CORRPLEXITY_MUL, 96, 32, 128, true);
 Tunable(LDSE_EXT, 124, 64, 256, true);
 
 Tunable(LMR_MIN_DEPTH, 393, 128, 640, true);

--- a/uci.cpp
+++ b/uci.cpp
@@ -422,7 +422,7 @@ inline void show_help() {
          << "  ucinewgame               - clear Hash and reset\n"
          << "  position                 - set board (fen <FEN> | startpos) [moves ...]\n"
          << "  go                       - start search. params: depth, nodes, movetime, movestogo\n"
-         << "                             wtime, btime, winc, binc, infinite\n"
+         << "                             wtime, btime, winc, binc, infinite, perft\n"
          << "  eval                     - show raw static eval\n"
          << "  ceval                    - show corrected static eval\n"
          << "  fen                      - show current position's fen\n"


### PR DESCRIPTION
Idea by @ProgramciDusunur
YOLO merge, it'll gain... (or with spsa), was 2.7 llr after like 1k games

```
Elo   | 1.17 +- 1.53 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.76 (-2.25, 2.89) [0.00, 4.00]
Games | N: 42326 W: 10099 L: 9956 D: 22271
Penta | [9, 4406, 12193, 4543, 12]
```
https://rmeguro.pythonanywhere.com/test/571/

bench: 9208189