### PR TITLE
feat: use tt score in probcut

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -564,7 +564,7 @@ i32 Raphael::negamax(
             && (!ttmove || !ttmove_quiet)
             && !(tthit && ttentry.fdepth >= pc_fdepth && ttentry.score < pc_beta))
         {
-            const i32 see_thresh = (pc_beta - ss->static_eval) * PC_SEE_FACTOR / 128;
+            const i32 see_thresh = (pc_beta - score_estimate) * PC_SEE_FACTOR / 128;
             auto generator = MoveGenerator::probcut(&mv->movelist, &position, &history, ttmove);
 
             while (const auto move = generator.next()) {


### PR DESCRIPTION
```
Elo   | 4.70 +- 3.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11080 W: 2728 L: 2578 D: 5774
Penta | [17, 1304, 2760, 1430, 29]
```
https://rmeguro.pythonanywhere.com/test/573/
bench: 8113823