### PR TITLE
feat: prefetch ti weights

### DIFF
--- a/src/eval/accumulator.cpp
+++ b/src/eval/accumulator.cpp
@@ -362,12 +362,16 @@ void NnueAccumulator::apply_ti_updates(
 
     for (const auto& feature : ti_adds) {
         const i32 fidx = feature.index(perspective, mirror);
-        if (fidx < N_THREATS) adds.push(fidx);
+        if (fidx >= N_THREATS) continue;
+        __builtin_prefetch(&weights[fidx]);
+        adds.push(fidx);
     }
 
     for (const auto& feature : ti_subs) {
         const i32 fidx = feature.index(perspective, mirror);
-        if (fidx < N_THREATS) subs.push(fidx);
+        if (fidx >= N_THREATS) continue;
+        __builtin_prefetch(&weights[fidx]);
+        subs.push(fidx);
     }
 
 #ifdef USE_SIMD


### PR DESCRIPTION
```
Elo   | 1.93 +- 1.55 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 4.00]
Games | N: 46144 W: 11245 L: 10989 D: 23910
Penta | [134, 4836, 12870, 5104, 128]
```
https://rmeguro.pythonanywhere.com/test/598/
bench: 10025875