### PR TITLE
feat: mix history into lmp margin

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -627,7 +627,9 @@ i32 Raphael::negamax(
 
             if (is_quiet) {
                 // late move pruning
-                if (move_searched >= LMP_TABLE[improving][fdepth / DEPTH_SCALE]) {
+                if (move_searched
+                    >= LMP_TABLE[improving][fdepth / DEPTH_SCALE] + hist * LMP_HIST_MUL / 8388608)
+                {
                     generator.skip_quiets();
                     continue;
                 }

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -139,21 +139,23 @@ inline bool set_tunable(const std::string& name, i32 value) {
     return false;
 }
 
-    #define Tunable(name, value, min_val, max_val, tunable)                                                                               \
+// clang-format off
+    #define Tunable(name, value, min_val, max_val, tunable)      \
         static_assert((min_val <= value) && (value <= max_val)); \
         inline raphael::SpinOption<tunable> name { #name, value, min_val, max_val, nullptr }
 
-    #define TunableCallback(name, value, min_val, max_val, callback, tunable)              \
+    #define TunableCallback(name, value, min_val, max_val, callback, tunable) \
         static_assert((min_val <= value) && (value <= max_val));              \
         inline raphael::SpinOption<tunable> name { #name, value, min_val, max_val, callback }
 #else
-    #define Tunable(name, value, min_val, max_val, tunable) \
-        static_assert((min_val <= value) && (value <= max_val));                 \
+    #define Tunable(name, value, min_val, max_val, tunable)      \
+        static_assert((min_val <= value) && (value <= max_val)); \
         static constexpr i32 name = value
 
-    #define TunableCallback(name, value, min_val, max_val, callback, tunable)                                       \
-        static_assert((min_val <= value) && (value <= max_val));                 \
+    #define TunableCallback(name, value, min_val, max_val, callback, tunable) \
+        static_assert((min_val <= value) && (value <= max_val));              \
         static constexpr i32 name = value
+// clang-format on
 #endif
 
 template <bool tunable>

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -139,20 +139,20 @@ inline bool set_tunable(const std::string& name, i32 value) {
     return false;
 }
 
-    #define Tunable(name, value, min_val, max_val, tunable)      \
+    #define Tunable(name, value, min_val, max_val, tunable)                                                                               \
         static_assert((min_val <= value) && (value <= max_val)); \
         inline raphael::SpinOption<tunable> name { #name, value, min_val, max_val, nullptr }
 
-    #define TunableCallback(name, value, min_val, max_val, callback, tunable) \
+    #define TunableCallback(name, value, min_val, max_val, callback, tunable)              \
         static_assert((min_val <= value) && (value <= max_val));              \
         inline raphael::SpinOption<tunable> name { #name, value, min_val, max_val, callback }
 #else
-    #define Tunable(name, value, min_val, max_val, tunable)      \
-        static_assert((min_val <= value) && (value <= max_val)); \
+    #define Tunable(name, value, min_val, max_val, tunable) \
+        static_assert((min_val <= value) && (value <= max_val));                 \
         static constexpr i32 name = value
 
-    #define TunableCallback(name, value, min_val, max_val, callback, tunable) \
-        static_assert((min_val <= value) && (value <= max_val));              \
+    #define TunableCallback(name, value, min_val, max_val, callback, tunable)                                       \
+        static_assert((min_val <= value) && (value <= max_val));                 \
         static constexpr i32 name = value
 #endif
 
@@ -250,6 +250,7 @@ Tunable(PC_SEE_FACTOR, 125, 64, 256, true);
 
 inline MultiArray<i32, 2, 256> LMP_TABLE;  // lmp moves threshold[improving][depth]
 TunableCallback(LMP_THRESH_BASE, 3, 1, 12, update_lmp_table, false);
+Tunable(LMP_HIST_MUL, 512, 256, 1024, true);
 
 Tunable(FP_MAX_DEPTH, 876, 512, 1536, true);
 Tunable(FP_MARGIN_DEPTH_MUL, 44, 32, 384, true);


### PR DESCRIPTION
```
Elo   | 1.99 +- 1.61 (95%)
SPRT  | 40.0+0.4s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 4.00]
Games | N: 42216 W: 9959 L: 9717 D: 22540
Penta | [24, 4750, 11326, 4976, 32]
```
https://rmeguro.pythonanywhere.com/test/607/
bench: 12287663