### PR TITLE
feat: fail firm multicut

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -757,8 +757,8 @@ i32 Raphael::negamax(
                     const i32 te_margin = TE_MARGIN_BASE + is_PV * TE_MARGIN_PV;
                     fext = SE_EXT + (score + de_margin < s_beta) * DE_EXT
                            + (is_quiet && score + te_margin < s_beta) * TE_EXT;
-                } else if (s_beta >= beta)
-                    return s_beta;  // multicut
+                } else if (score >= beta)
+                    return (utils::is_mate(score)) ? score : (score + beta) / 2;  // multicut
                 else if (cutnode)
                     fext = -CUTNODE_NE_RED;  // cutnode negative extensions
                 else if (ttentry.score >= beta)


### PR DESCRIPTION
stc:
```
Elo   | 5.19 +- 3.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 11038 W: 2749 L: 2584 D: 5705
Penta | [32, 1274, 2755, 1413, 45]
```
https://rmeguro.pythonanywhere.com/test/632/

ltc:
```
Elo   | 4.05 +- 2.82 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 13892 W: 3427 L: 3265 D: 7200
Penta | [7, 1542, 3689, 1698, 10]
```
https://rmeguro.pythonanywhere.com/test/635/

bench: 8627917