### PR TITLE
feat: scale score up if score consistently good and vice versa (optimism)

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -197,7 +197,7 @@ i32 Raphael::static_eval(bool corrected) {
 
     auto& tdata = *thread_data_[0];
     i32 corrplexity;
-    const auto raw_score = tdata.position.evaluate(!params_.datagen);
+    const auto raw_score = tdata.position.evaluate();
     return (corrected) ? adjust_score(tdata, raw_score, corrplexity) : raw_score;
 }
 
@@ -386,8 +386,19 @@ i32 Raphael::adjust_score(const ThreadData& tdata, i32 raw_static_eval, i32& cor
     const auto* shared_corrhist = shared_corrhist_.get(tdata.thread_id);
     const auto& board = position.board();
 
-    // halfmove scaling
-    if (!params_.datagen) raw_static_eval = raw_static_eval * (200 - board.halfmoves()) / 200;
+    if (!params_.datagen) {
+        // material scaling
+        const i32 material_scale = MAT_SCALE_BASE
+                                   + board.occ(chess::PieceType::PAWN).count() * MAT_SCALE_PAWN
+                                   + board.occ(chess::PieceType::KNIGHT).count() * MAT_SCALE_KNIGHT
+                                   + board.occ(chess::PieceType::BISHOP).count() * MAT_SCALE_BISHOP
+                                   + board.occ(chess::PieceType::ROOK).count() * MAT_SCALE_ROOK
+                                   + board.occ(chess::PieceType::QUEEN).count() * MAT_SCALE_QUEEN;
+        raw_static_eval = raw_static_eval * material_scale / 32768;
+
+        // halfmove scaling
+        raw_static_eval = raw_static_eval * (200 - board.halfmoves()) / 200;
+    }
 
     // corrhist
     const i32 correction = corrhist::get(position, thread_corrhist, shared_corrhist);
@@ -551,7 +562,7 @@ i32 Raphael::negamax(
             if (tthit && ttentry.static_eval != NONE_SCORE)
                 raw_static_eval = ttentry.static_eval;
             else if (!tt_.get_static_eval(ttkey, raw_static_eval)) {
-                raw_static_eval = position.evaluate(!params_.datagen);
+                raw_static_eval = position.evaluate();
                 tt_.set_static_eval(ttkey, raw_static_eval);
             }
 
@@ -938,8 +949,7 @@ i32 Raphael::quiescence(ThreadData& tdata, const i32 ply, i32 alpha, i32 beta, M
     const bool in_check = board.in_check();
     i32 corrplexity = 0;
     if (ply >= MAX_DEPTH - 1)
-        return (in_check) ? 0
-                          : adjust_score(tdata, position.evaluate(!params_.datagen), corrplexity);
+        return (in_check) ? 0 : adjust_score(tdata, position.evaluate(), corrplexity);
 
     // probe transposition table
     const auto ttkey = board.hash();
@@ -967,7 +977,7 @@ i32 Raphael::quiescence(ThreadData& tdata, const i32 ply, i32 alpha, i32 beta, M
         if (tthit && ttentry.static_eval != NONE_SCORE)
             raw_static_eval = ttentry.static_eval;
         else if (!tt_.get_static_eval(ttkey, raw_static_eval)) {
-            raw_static_eval = position.evaluate(!params_.datagen);
+            raw_static_eval = position.evaluate();
             tt_.set_static_eval(ttkey, raw_static_eval);
         }
 

--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -387,14 +387,15 @@ i32 Raphael::adjust_score(const ThreadData& tdata, i32 raw_static_eval, i32& cor
     const auto& board = position.board();
 
     if (!params_.datagen) {
-        // material scaling
-        const i32 material_scale = MAT_SCALE_BASE
-                                   + board.occ(chess::PieceType::PAWN).count() * MAT_SCALE_PAWN
-                                   + board.occ(chess::PieceType::KNIGHT).count() * MAT_SCALE_KNIGHT
-                                   + board.occ(chess::PieceType::BISHOP).count() * MAT_SCALE_BISHOP
-                                   + board.occ(chess::PieceType::ROOK).count() * MAT_SCALE_ROOK
-                                   + board.occ(chess::PieceType::QUEEN).count() * MAT_SCALE_QUEEN;
-        raw_static_eval = raw_static_eval * material_scale / 32768;
+        // material scaling and optimism
+        const i32 material = board.occ(chess::PieceType::PAWN).count() * MAT_SCALE_PAWN
+                             + board.occ(chess::PieceType::KNIGHT).count() * MAT_SCALE_KNIGHT
+                             + board.occ(chess::PieceType::BISHOP).count() * MAT_SCALE_BISHOP
+                             + board.occ(chess::PieceType::ROOK).count() * MAT_SCALE_ROOK
+                             + board.occ(chess::PieceType::QUEEN).count() * MAT_SCALE_QUEEN;
+        const i32 material_scale = MAT_SCALE_BASE + material;
+        const i32 optimism_bonus = tdata.optimism[board.stm()] * (OPT_SCALE_BASE + material);
+        raw_static_eval = ((raw_static_eval * material_scale) + optimism_bonus) / 32768;
 
         // halfmove scaling
         raw_static_eval = raw_static_eval * (200 - board.halfmoves()) / 200;
@@ -413,12 +414,16 @@ void Raphael::iterative_deepen(ThreadData& tdata) {
     const i32 thread_id = tdata.thread_id;
     auto* ss = &tdata.search_stack[2];
     auto* mv = tdata.move_stack;
+    const auto& board = tdata.position.board();
+    tdata.optimism = {};
 
     auto& result = tdata.result;
     result.pv = &ss->pv;
     result.score = -INF_SCORE;
     result.depth = 1;
     result.bound = UCIScoreType::UPPER;
+
+    i32 avg_score = NONE_SCORE;
 
     // begin iterative deepening
     for (; result.depth <= MAX_DEPTH; result.depth++) {
@@ -453,6 +458,7 @@ void Raphael::iterative_deepen(ThreadData& tdata) {
                 result.bound = UCIScoreType::LOWER;
             } else {
                 result.bound = UCIScoreType::EXACT;
+                avg_score = (avg_score == NONE_SCORE) ? iterscore : (avg_score + iterscore) / 2;
                 break;
             }
 
@@ -464,6 +470,11 @@ void Raphael::iterative_deepen(ThreadData& tdata) {
 
         if (stop_.load(memory_order_relaxed)) break;  // don't use results if timeout
         result.score = iterscore;
+
+        // update optimism
+        const auto optimism = OPT_MAX_BONUS * avg_score / (abs(avg_score) + OPT_STRETCH);
+        tdata.optimism[board.stm()] = optimism;
+        tdata.optimism[!board.stm()] = -optimism;
 
         // check soft limit
         if (tm_.is_soft_limit_reached(

--- a/src/Raphael/Raphael.h
+++ b/src/Raphael/Raphael.h
@@ -6,6 +6,7 @@
 #include <Raphael/tm.h>
 #include <Raphael/transposition.h>
 
+#include <array>
 #include <atomic>
 #include <barrier>
 #include <memory>
@@ -98,6 +99,7 @@ private:
         History history;
         CorrectionHistory corrhist;
         SearchResult result;
+        std::array<i32, 2> optimism;
         i32 min_nmp_ply;
         i32 thread_id;
     };

--- a/src/Raphael/position.h
+++ b/src/Raphael/position.h
@@ -159,24 +159,12 @@ public:
 
     /** Evaluates the current board from the current side to move
      *
-     * \param do_scaling whether to apply material scaling
      * \returns the NNUE evaluation of the board in centipawns
      */
-    i32 evaluate(bool do_scaling)
+    i32 evaluate()
         requires(include_net)
     {
-        i32 static_eval = net_.evaluate(current_);
-        if (do_scaling) {
-            // material scaling
-            const i32 material_scale
-                = MAT_SCALE_BASE + current_.occ(chess::PieceType::PAWN).count() * MAT_SCALE_PAWN
-                  + current_.occ(chess::PieceType::KNIGHT).count() * MAT_SCALE_KNIGHT
-                  + current_.occ(chess::PieceType::BISHOP).count() * MAT_SCALE_BISHOP
-                  + current_.occ(chess::PieceType::ROOK).count() * MAT_SCALE_ROOK
-                  + current_.occ(chess::PieceType::QUEEN).count() * MAT_SCALE_QUEEN;
-            static_eval = static_eval * material_scale / 32768;
-        }
-        return static_eval;
+        return net_.evaluate(current_);
     }
 
 

--- a/src/Raphael/tunable.h
+++ b/src/Raphael/tunable.h
@@ -367,6 +367,10 @@ Tunable(MAT_SCALE_BISHOP, 340, 200, 500, false);
 Tunable(MAT_SCALE_ROOK, 590, 400, 800, false);
 Tunable(MAT_SCALE_QUEEN, 970, 800, 1400, false);
 
+Tunable(OPT_SCALE_BASE, 2000, 1000, 4000, false);
+Tunable(OPT_MAX_BONUS, 150, 75, 300, false);
+Tunable(OPT_STRETCH, 100, 50, 200, false);
+
 // commands
 #ifndef MEASURE_SPARSITY
 static constexpr i32 BENCH_DEPTH = 14;

--- a/src/tests/position.cpp
+++ b/src/tests/position.cpp
@@ -26,7 +26,7 @@ public:
 
         for (const auto& smove : moves) {
             position_.make_move(smove.move);
-            const auto eval = position_.evaluate(false);
+            const auto eval = position_.evaluate();
 
             const auto& newboard = position_.board();
             refnet_.observer().set_board(newboard);
@@ -49,7 +49,7 @@ public:
 
         // check nullmove
         position_.make_nullmove();
-        const auto eval = position_.evaluate(false);
+        const auto eval = position_.evaluate();
 
         const auto& newboard = position_.board();
         refnet_.observer().set_board(newboard);


### PR DESCRIPTION
```
Elo   | 5.87 +- 3.51 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 8344 W: 2024 L: 1883 D: 4437
Penta | [3, 844, 2337, 985, 3]
```
https://rmeguro.pythonanywhere.com/test/652/
bench: 8829226