### PR TITLE
feat: mix threats into capthist

### DIFF
--- a/src/Raphael/Raphael.cpp
+++ b/src/Raphael/Raphael.cpp
@@ -711,7 +711,7 @@ i32 Raphael::negamax(
         const bool is_quiet = board.is_quiet(move);
         const auto base_lmr = LMR_TABLE[is_quiet][fdepth / DEPTH_SCALE][move_searched + 1];
         const auto hist = (is_quiet) ? history.get_quietscore(move, position)
-                                     : history.get_noisyscore(move, board.get_captured(move));
+                                     : history.get_noisyscore(move, position);
 
         // moveloop pruning
         if (!is_root && !utils::is_loss(bestscore) && (!params_.datagen || !is_PV)) {
@@ -887,7 +887,7 @@ i32 Raphael::negamax(
                             CAPTHIST_BONUS_BASE,
                             CAPTHIST_BONUS_MAX
                         );
-                        history.update_noisy(bestmove, board.get_captured(bestmove), bonus);
+                        history.update_noisy(bestmove, position, bonus);
                     }
 
                     // always apply capthist penalty
@@ -898,7 +898,7 @@ i32 Raphael::negamax(
                         CAPTHIST_PENALTY_MAX
                     );
                     for (const auto noisymove : mv->noisylist)
-                        history.update_noisy(noisymove, board.get_captured(noisymove), penalty);
+                        history.update_noisy(noisymove, position, penalty);
 
                     break;  // prune
                 }

--- a/src/Raphael/history.cpp
+++ b/src/Raphael/history.cpp
@@ -53,8 +53,11 @@ void History::update_quiet(chess::Move move, const Position<true>& position, i32
         cont_entry(move, moving, prev4).update_with_base(bonus, total_conthist);
 }
 
-void History::update_noisy(chess::Move move, chess::Piece captured, i32 bonus) {
-    capt_entry(move, captured).update(bonus);
+void History::update_noisy(chess::Move move, const Position<true>& position, i32 bonus) {
+    const auto& board = position.board();
+    const auto captured = board.get_captured(move);
+    const auto threats = board.threats();
+    capt_entry(move, captured, threats).update(bonus);
 }
 
 
@@ -90,8 +93,11 @@ i32 History::get_quietscore(chess::Move move, const Position<true>& position) co
     return score;
 }
 
-i32 History::get_noisyscore(chess::Move move, chess::Piece captured) const {
-    return capt_entry(move, captured);
+i32 History::get_noisyscore(chess::Move move, const Position<true>& position) const {
+    const auto& board = position.board();
+    const auto captured = board.get_captured(move);
+    const auto threats = board.threats();
+    return capt_entry(move, captured, threats);
 }
 
 
@@ -141,9 +147,17 @@ HistoryEntry& History::cont_entry(
     return cont_hist_[prev_move.moving][prev_move.move.to()][moving][move.to()];
 }
 
-const HistoryEntry& History::capt_entry(chess::Move move, chess::Piece captured) const {
-    return capt_hist_[move.from()][move.to()][captured];
+const HistoryEntry& History::capt_entry(
+    chess::Move move, chess::Piece captured, chess::BitBoard threats
+) const {
+    const auto from_attacked = threats.is_set(move.from());
+    const auto to_attacked = threats.is_set(move.to());
+    return capt_hist_[move.from()][move.to()][captured][from_attacked][to_attacked];
 }
-HistoryEntry& History::capt_entry(chess::Move move, chess::Piece captured) {
-    return capt_hist_[move.from()][move.to()][captured];
+HistoryEntry& History::capt_entry(
+    chess::Move move, chess::Piece captured, chess::BitBoard threats
+) {
+    const auto from_attacked = threats.is_set(move.from());
+    const auto to_attacked = threats.is_set(move.to());
+    return capt_hist_[move.from()][move.to()][captured][from_attacked][to_attacked];
 }

--- a/src/Raphael/history.h
+++ b/src/Raphael/history.h
@@ -30,7 +30,7 @@ private:
     HistoryEntry butterfly_hist_[64][64][2][2];      // [from][to][from attacked][to attacked]
     HistoryEntry pawn_hist_[PAWNHIST_SIZE][12][64];  // [pawn key][from][to]
     HistoryEntry cont_hist_[12][64][12][64];         // [prev from][prev to][from][to]
-    HistoryEntry capt_hist_[64][64][13];  // [from][to][piece, 12 for non-capture queening]
+    HistoryEntry capt_hist_[64][64][13][2][2];  // [from][to][piece][from attacked][to attacked]
 
 public:
     /** Initializes all the history tables with zeros */
@@ -59,10 +59,10 @@ public:
     /** Applies a bonus to the noisy history score
      *
      * \param move noisy move
-     * \param captured the captured piece
+     * \param position current position
      * \param bonus bonus to apply, negative to apply penalty
      */
-    void update_noisy(chess::Move move, chess::Piece captured, i32 bonus);
+    void update_noisy(chess::Move move, const Position<true>& position, i32 bonus);
 
 
     /** Returns the continuation history score
@@ -84,10 +84,10 @@ public:
     /** Returns the noisy history score
      *
      * \param move noisy move
-     * \param captured the captured piece
+     * \param position current position
      * \returns noisy history score
      */
-    [[nodiscard]] i32 get_noisyscore(chess::Move move, chess::Piece captured) const;
+    [[nodiscard]] i32 get_noisyscore(chess::Move move, const Position<true>& position) const;
 
 
     /** Zeros out all the histories */
@@ -135,9 +135,14 @@ private:
      *
      * \param move move to get history for
      * \param captured the captured piece
+     * \param threats squares attacked by the current not side to move
      * \returns capture history entry
      */
-    [[nodiscard]] const HistoryEntry& capt_entry(chess::Move move, chess::Piece captured) const;
-    [[nodiscard]] HistoryEntry& capt_entry(chess::Move move, chess::Piece captured);
+    [[nodiscard]] const HistoryEntry& capt_entry(
+        chess::Move move, chess::Piece captured, chess::BitBoard threats
+    ) const;
+    [[nodiscard]] HistoryEntry& capt_entry(
+        chess::Move move, chess::Piece captured, chess::BitBoard threats
+    );
 };
 }  // namespace raphael

--- a/src/Raphael/movepick.cpp
+++ b/src/Raphael/movepick.cpp
@@ -275,7 +275,7 @@ void MoveGenerator::score_noisies() {
         const auto victim = board.get_captured(smove.move);
 
         i32 score = 0;
-        score += history_->get_noisyscore(smove.move, victim) / CAPTHIST_DIV;
+        score += history_->get_noisyscore(smove.move, *position_) / CAPTHIST_DIV;
         score += SEE_TABLE[victim];
         if (smove.move.type() == chess::Move::PROMOTION)
             score += SEE_TABLE[smove.move.promotion_type()] - SEE_TABLE[chess::PieceType::PAWN];


### PR DESCRIPTION
stc:
```
Elo   | 3.28 +- 2.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 20364 W: 5056 L: 4864 D: 10444
Penta | [77, 2359, 5106, 2575, 65]
```
https://rmeguro.pythonanywhere.com/test/671/

ltc:
```
Elo   | 4.15 +- 2.86 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 4.00]
Games | N: 13818 W: 3287 L: 3122 D: 7409
Penta | [11, 1560, 3597, 1735, 6]
```
https://rmeguro.pythonanywhere.com/test/672/

bench: 7414783